### PR TITLE
bri 1 implementation and rebase

### DIFF
--- a/examples/bri-1/base-example/Makefile
+++ b/examples/bri-1/base-example/Makefile
@@ -12,10 +12,10 @@ reset: stop clean
 restart: stop start
 
 start:
-	docker-compose up -d --remove-orphans
+	docker-compose up -d --remove-orphans && docker network prune -f && docker network prune -f
 
 start-attached:
 	docker-compose up --remove-orphans
 
 stop:
-	docker-compose down --remove-orphans
+	docker-compose down --remove-orphans && prvd baseline stack stop --name BobCorp && prvd baseline stack stop --name AliceCorp

--- a/examples/bri-1/base-example/docker-compose.yml
+++ b/examples/bri-1/base-example/docker-compose.yml
@@ -104,12 +104,13 @@ services:
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
-      - alice-vault
     environment:
       - DATABASE_HOST=alice-postgres
       - DATABASE_NAME=ident_dev
       - DATABASE_USER=ident
       - DATABASE_PASSWORD=ident
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
       - NATS_CLIENT_PREFIX=alice-ident
       - NATS_URL=nats://alice-nats:4222
       - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
@@ -119,7 +120,6 @@ services:
       - VAULT_API_HOST=alice-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-ident:8080/status"]
       interval: 1m
@@ -138,16 +138,18 @@ services:
     entrypoint: ./ops/run_consumer.sh
     container_name: alice-ident-consumer
     depends_on:
+      - alice-ident
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
-      - alice-vault
     environment:
       - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
       - DATABASE_HOST=alice-postgres
       - DATABASE_NAME=ident_dev
       - DATABASE_USER=ident
       - DATABASE_PASSWORD=ident
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=alice-ident-consumer
       - NATS_URL=nats://alice-nats:4222
@@ -158,7 +160,6 @@ services:
       - VAULT_API_HOST=alice-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-ident:8080/status"]
       interval: 1m
@@ -171,13 +172,14 @@ services:
     restart: always
 
   alice-nchain:
-    image: provide/nchain:bri-1
+    image: provide/nchain
     container_name: alice-nchain
     depends_on:
       - alice-ident
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
+      - alice-vault
     environment:
       - DATABASE_HOST=alice-postgres
       - DATABASE_NAME=nchain_dev
@@ -195,7 +197,6 @@ services:
       - VAULT_API_HOST=alice-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"]
       interval: 1m
@@ -210,7 +211,7 @@ services:
     restart: always
 
   alice-nchain-consumer:
-    image: provide/nchain:bri-1
+    image: provide/nchain
     entrypoint: ./ops/run_consumer.sh
     container_name: alice-nchain-consumer
     depends_on:
@@ -218,6 +219,7 @@ services:
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
+      - alice-vault
     environment:
       - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
       - DATABASE_HOST=alice-postgres
@@ -236,7 +238,6 @@ services:
       - VAULT_API_HOST=alice-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"]
       interval: 1m
@@ -248,8 +249,85 @@ services:
       - alice
     restart: always
 
+  alice-privacy:
+    image: provide/privacy
+    container_name: alice-privacy
+    depends_on:
+      - alice-ident
+      - alice-nats-streaming
+      - alice-postgres
+      - alice-privacy-consumer
+      - alice-redis
+      - alice-vault
+    environment:
+      - DATABASE_HOST=alice-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=alice-privacy
+      - NATS_URL=nats://alice-nats:4222
+      - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - PORT=8080
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://alice-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: alice-privacy
+    networks:
+      - alice
+    ports:
+      - 8084:8080
+    restart: always
+
+  alice-privacy-consumer:
+    image: provide/privacy
+    entrypoint: ./ops/run_consumer.sh
+    container_name: alice-privacy-consumer
+    depends_on:
+      - alice-nats-streaming
+      - alice-postgres
+      - alice-redis
+      - alice-vault
+    environment:
+      - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
+      - DATABASE_HOST=alice-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=alice-privacy-consumer
+      - NATS_URL=nats://alice-nats:4222
+      - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://alice-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: alice-privacy-consumer
+    networks:
+      - alice
+    restart: always
+
   alice-statsdaemon:
-    image: provide/nchain:bri-1
+    image: provide/nchain
     entrypoint: ./ops/run_statsdaemon.sh
     container_name: alice-statsdaemon
     depends_on:
@@ -273,7 +351,6 @@ services:
       - VAULT_API_HOST=alice-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"]
       interval: 1m
@@ -289,14 +366,22 @@ services:
     image: provide/vault
     container_name: alice-vault
     depends_on:
+      - alice-ident
       - alice-postgres
+      - alice-redis
     environment:
       - DATABASE_HOST=alice-postgres
       - DATABASE_NAME=vault_dev
       - DATABASE_USER=vault
       - DATABASE_PASSWORD=vault
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - PORT=8080
+      - REDIS_HOSTS=alice-redis:6379
+      - SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
       - SEAL_UNSEAL_VALIDATION_HASH=0x05598175ac56c919ca39be16fdbb4335f755e53c27aca03717dc1b89e206aad1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-vault:8080/status"]
@@ -310,36 +395,6 @@ services:
     ports:
       - 8082:8080
     restart: always
-
-  alice-nethermind:
-    image: provide/nethermind:bri-1
-    container_name: alice-nethermind
-    environment:
-      - NETHERMIND_CONFIG=baseline
-      - NETHERMIND_INITCONFIG_STATICNODESPATH=Data/static-nodes-baseline-hosts.json
-      - NETHERMIND_JSONRPCCONFIG_ENABLED=true
-      - NETHERMIND_JSONRPCCONFIG_HOST=0.0.0.0
-      - NETHERMIND_JSONRPCCONFIG_PORT=8522
-      - NETHERMIND_KEYSTORECONFIG_TESTNODEKEY=020102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
-      - NETHERMIND_NETWORKCONFIG_DISCOVERYPORT=30222
-      - NETHERMIND_NETWORKCONFIG_P2PPORT=30222
-      - NETHERMIND_VAULTCONFIG_HOST=alice-vault:8082
-    healthcheck:
-      test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:8522"]
-      interval: 1m
-      timeout: 1s
-      retries: 2
-      start_period: 10s
-    hostname: alice-nethermind
-    networks:
-      - alice
-      - bob
-    ports:
-      - 8522:8522
-      - 30222:30222
-    restart: always
-    volumes:
-      - ./ops/await_tcp.sh:/usr/local/bin/await_tcp.sh:cached
 
   # bob
 
@@ -377,6 +432,8 @@ services:
     hostname: bob-redis
     networks:
       - bob
+    ports:
+      - 6380:6379
     restart: always
 
   bob-nats:
@@ -441,12 +498,13 @@ services:
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
-      - bob-vault
     environment:
       - DATABASE_HOST=bob-postgres
       - DATABASE_NAME=ident_dev
       - DATABASE_USER=ident
       - DATABASE_PASSWORD=ident
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
       - NATS_CLIENT_PREFIX=bob-ident
       - NATS_URL=nats://bob-nats:4222
       - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
@@ -456,7 +514,6 @@ services:
       - VAULT_API_HOST=bob-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-ident:8080/status"]
       interval: 1m
@@ -475,16 +532,18 @@ services:
     entrypoint: ./ops/run_consumer.sh
     container_name: bob-ident-consumer
     depends_on:
+      - bob-ident
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
-      - bob-vault
     environment:
       - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
       - DATABASE_HOST=bob-postgres
       - DATABASE_NAME=ident_dev
       - DATABASE_USER=ident
       - DATABASE_PASSWORD=ident
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=bob-ident-consumer
       - NATS_URL=nats://bob-nats:4222
@@ -495,7 +554,6 @@ services:
       - VAULT_API_HOST=bob-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-ident:8080/status"]
       interval: 1m
@@ -508,13 +566,14 @@ services:
     restart: always
 
   bob-nchain:
-    image: provide/nchain:bri-1
+    image: provide/nchain
     container_name: bob-nchain
     depends_on:
       - bob-ident
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
+      - bob-vault
     environment:
       - DATABASE_HOST=bob-postgres
       - DATABASE_NAME=nchain_dev
@@ -532,7 +591,6 @@ services:
       - VAULT_API_HOST=bob-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"]
       interval: 1m
@@ -547,7 +605,7 @@ services:
     restart: always
 
   bob-nchain-consumer:
-    image: provide/nchain:bri-1
+    image: provide/nchain
     entrypoint: ./ops/run_consumer.sh
     container_name: bob-nchain-consumer
     depends_on:
@@ -555,6 +613,7 @@ services:
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
+      - bob-vault
     environment:
       - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
       - DATABASE_HOST=bob-postgres
@@ -573,7 +632,6 @@ services:
       - VAULT_API_HOST=bob-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"]
       interval: 1m
@@ -585,8 +643,85 @@ services:
       - bob
     restart: always
 
+  bob-privacy:
+    image: provide/privacy
+    container_name: bob-privacy
+    depends_on:
+      - bob-ident
+      - bob-nats-streaming
+      - bob-postgres
+      - bob-privacy-consumer
+      - bob-redis
+      - bob-vault
+    environment:
+      - DATABASE_HOST=bob-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=bob-privacy
+      - NATS_URL=nats://bob-nats:4222
+      - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - PORT=8080
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://bob-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: bob-privacy
+    networks:
+      - bob
+    ports:
+      - 8087:8080
+    restart: always
+
+  bob-privacy-consumer:
+    image: provide/privacy
+    entrypoint: ./ops/run_consumer.sh
+    container_name: bob-privacy-consumer
+    depends_on:
+      - bob-nats-streaming
+      - bob-postgres
+      - bob-redis
+      - bob-vault
+    environment:
+      - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
+      - DATABASE_HOST=bob-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=bob-privacy-consumer
+      - NATS_URL=nats://bob-nats:4222
+      - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://bob-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: bob-privacy-consumer
+    networks:
+      - bob
+    restart: always
+
   bob-statsdaemon:
-    image: provide/nchain:bri-1
+    image: provide/nchain
     entrypoint: ./ops/run_statsdaemon.sh
     container_name: bob-statsdaemon
     depends_on:
@@ -610,7 +745,6 @@ services:
       - VAULT_API_HOST=bob-vault:8080
       - VAULT_API_SCHEME=http
       - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
-      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"]
       interval: 1m
@@ -626,14 +760,22 @@ services:
     image: provide/vault
     container_name: bob-vault
     depends_on:
+      - bob-ident
       - bob-postgres
+      - bob-redis
     environment:
       - DATABASE_HOST=bob-postgres
       - DATABASE_NAME=vault_dev
       - DATABASE_USER=vault
       - DATABASE_PASSWORD=vault
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - PORT=8080
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - REDIS_HOSTS=bob-redis:6379
+      - SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
       - SEAL_UNSEAL_VALIDATION_HASH=0x1c1381fd075f1ee3d42799bb8da0602a2afb9ef4b492bf1eae72399ecc81b0f0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-vault:8080/status"]
@@ -647,36 +789,6 @@ services:
     ports:
       - 8083:8080
     restart: always
-
-  bob-nethermind:
-    image: provide/nethermind:bri-1
-    container_name: bob-nethermind
-    environment:
-      - NETHERMIND_CONFIG=baseline
-      - NETHERMIND_INITCONFIG_STATICNODESPATH=Data/static-nodes-baseline-hosts.json
-      - NETHERMIND_JSONRPCCONFIG_ENABLED=true
-      - NETHERMIND_JSONRPCCONFIG_HOST=0.0.0.0
-      - NETHERMIND_JSONRPCCONFIG_PORT=8511
-      - NETHERMIND_KEYSTORECONFIG_TESTNODEKEY=120102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
-      - NETHERMIND_NETWORKCONFIG_DISCOVERYPORT=30111
-      - NETHERMIND_NETWORKCONFIG_P2PPORT=30111
-      - NETHERMIND_VAULTCONFIG_HOST=bob-vault:8083
-    healthcheck:
-      test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:8511"]
-      interval: 1m
-      timeout: 1s
-      retries: 2
-      start_period: 10s
-    hostname: bob-nethermind
-    networks:
-      - alice
-      - bob
-    ports:
-      - 8511:8511
-      - 30111:30111
-    restart: always
-    volumes:
-      - ./ops/await_tcp.sh:/usr/local/bin/await_tcp.sh:cached
 
 networks:
   alice:

--- a/examples/bri-1/base-example/ops/splunk/docker-compose.yml
+++ b/examples/bri-1/base-example/ops/splunk/docker-compose.yml
@@ -5,7 +5,7 @@ x-logging:
   driver: splunk
   options:
     splunk-token: 11111111-1111-1111-1111-1111111111113
-    splunk-url: https://localhost:8088
+    splunk-url: https://localhost:8090
     splunk-index: logs
     splunk-sourcetype: docker
     splunk-insecureskipverify: "true"
@@ -43,6 +43,8 @@ services:
   alice-redis:
     image: redis
     container_name: alice-redis
+    environment:
+      - SYSLOG_ENDPOINT=splunk:8514
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 1m
@@ -61,6 +63,7 @@ services:
     container_name: alice-provide-nats
     command: ["-auth", "testtoken", "-p", "4222", "--remote_syslog", "udp://splunk:8514", "-D", "-V"]
     environment:
+      SYSLOG_ENDPOINT: splunk:8514
       JWT_SIGNER_PUBLIC_KEY: |-
         -----BEGIN PUBLIC KEY-----
         MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAullT/WoZnxecxKwQFlwE
@@ -120,6 +123,7 @@ services:
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
+      - alice-vault
     environment:
       - DATABASE_HOST=alice-postgres
       - DATABASE_NAME=ident_dev
@@ -132,6 +136,10 @@ services:
       - LOG_LEVEL=DEBUG
       - PORT=8080
       - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-ident:8080/status"]
       interval: 1m
@@ -153,6 +161,7 @@ services:
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
+      - alice-vault
     environment:
       - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
       - DATABASE_HOST=alice-postgres
@@ -163,13 +172,16 @@ services:
       - NATS_CLIENT_PREFIX=alice-ident-consumer
       - NATS_URL=nats://alice-nats:4222
       - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
-      - PORT=8080
+      - NCHAIN_API_HOST=alice-nchain:8080
+      - NCHAIN_API_SCHEME=http
       - REDIS_HOSTS=alice-redis:6379
       - SYSLOG_ENDPOINT=splunk:8514
-      - VAULT_API_SCHEME=http
       - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://alice-ident:8080/status"] # FIXME
+      test: ["CMD", "curl", "-f", "http://alice-ident:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -183,6 +195,7 @@ services:
     image: provide/nchain
     container_name: alice-nchain
     depends_on:
+      - alice-ident
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
@@ -191,13 +204,20 @@ services:
       - DATABASE_NAME=nchain_dev
       - DATABASE_USER=nchain
       - DATABASE_PASSWORD=nchain
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=alice-nchain
       - NATS_URL=nats://alice-nats:4222
       - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - PAYMENTS_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImU2OmY3OmQ1OjI0OmUyOjU5OjA2OjJiOmJjOmEyOjhjOjM1OjlkOmNhOjBhOjg3IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjAwNzA5Njg3LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiJkMDIzM2JlZC1iMThkLTRmNGEtODNlYS02MjBmYjdjYTY0NWMiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4wYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJuZXR3b3JrLiouY29ubmVjdG9yLioiLCJuZXR3b3JrLiouc3RhdHVzIiwicGxhdGZvcm0uXHUwMDNlIl19fX0sInBydmQiOnsiYXBwbGljYXRpb25faWQiOiIwYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJleHRlbmRlZCI6eyJwZXJtaXNzaW9ucyI6eyIqIjo1MTB9fSwicGVybWlzc2lvbnMiOjUxMH0sInN1YiI6ImFwcGxpY2F0aW9uOjBjNWE5ZmViLTE2MGMtNGZlMS05MTBlLTE4NzQyZjg2NGJjZSJ9.SUd50x0g6opm2oU9zFMu6rLpc-22WeEi50OByzluBsoV1fCN1INzqHnCJAMLC2myXIDRKaP1Q-MZVAw97hpzuGQjXEY8yobX0Br3DjGADqaM3iJiaD4GB73lZtd2w2jAsy3PDfvEE_dd9SalGA90WLoSUwkEObFxqufj2vnMVuiH1UwUnMawuVGfZPzZ7Wtoe9K4sq0E7qYiND5lgz0tyDnP7FWyd_wHEwjan_AhabgUJA0w5XlUq7AnjHe-NTrCzU_ZTJ6Hdvxy_uNRSOOv4fV4_MVRomqPePBTPXeeLBpjpsVVKSsKGrP3z7oAWclCm21i-9hEvyEeIN3TV71KgYDLaMtHsHZYPdo1WaKdnq49uPVgXbzCsAAWvgjKbOT62VciQVgv1ognm_22gPgxRksrOAhArSUX_LP0NLMxXDGP0TGwx218QgNW4qj6OxQZrBCO5YRl0Lb-mQVZZ2L3AQXk39gvArTnqIQ8aV9hwLeiBqq1qZU7Q77RUHI-yMUfkH3FAy2xQS1AIn7-rM6rCXtjXVUzdjm1_6HrJkDjS20HUFsaqmKacPxlkkCFa08zxsIsuU_h9LY4VdeVHJKnvWUFWy2M6jYvKIJRuF0Dk1PCTLqbiBUmyCnr20qGe5Y8Vc9c3pvuudm6hdk6aGa3zuNOIzftPthPEoUzoG4qZ3c
       - PORT=8080
       - REDIS_HOSTS=alice-redis:6379
       - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"]
       interval: 1m
@@ -216,6 +236,7 @@ services:
     entrypoint: ./ops/run_consumer.sh
     container_name: alice-nchain-consumer
     depends_on:
+      - alice-ident
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
@@ -225,15 +246,22 @@ services:
       - DATABASE_NAME=nchain_dev
       - DATABASE_USER=nchain
       - DATABASE_PASSWORD=nchain
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=alice-nchain-consumer
       - NATS_URL=nats://alice-nats:4222
       - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
       - NATS_TOKEN=testtoken
+      - PAYMENTS_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImU2OmY3OmQ1OjI0OmUyOjU5OjA2OjJiOmJjOmEyOjhjOjM1OjlkOmNhOjBhOjg3IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjAwNzA5Njg3LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiJkMDIzM2JlZC1iMThkLTRmNGEtODNlYS02MjBmYjdjYTY0NWMiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4wYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJuZXR3b3JrLiouY29ubmVjdG9yLioiLCJuZXR3b3JrLiouc3RhdHVzIiwicGxhdGZvcm0uXHUwMDNlIl19fX0sInBydmQiOnsiYXBwbGljYXRpb25faWQiOiIwYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJleHRlbmRlZCI6eyJwZXJtaXNzaW9ucyI6eyIqIjo1MTB9fSwicGVybWlzc2lvbnMiOjUxMH0sInN1YiI6ImFwcGxpY2F0aW9uOjBjNWE5ZmViLTE2MGMtNGZlMS05MTBlLTE4NzQyZjg2NGJjZSJ9.SUd50x0g6opm2oU9zFMu6rLpc-22WeEi50OByzluBsoV1fCN1INzqHnCJAMLC2myXIDRKaP1Q-MZVAw97hpzuGQjXEY8yobX0Br3DjGADqaM3iJiaD4GB73lZtd2w2jAsy3PDfvEE_dd9SalGA90WLoSUwkEObFxqufj2vnMVuiH1UwUnMawuVGfZPzZ7Wtoe9K4sq0E7qYiND5lgz0tyDnP7FWyd_wHEwjan_AhabgUJA0w5XlUq7AnjHe-NTrCzU_ZTJ6Hdvxy_uNRSOOv4fV4_MVRomqPePBTPXeeLBpjpsVVKSsKGrP3z7oAWclCm21i-9hEvyEeIN3TV71KgYDLaMtHsHZYPdo1WaKdnq49uPVgXbzCsAAWvgjKbOT62VciQVgv1ognm_22gPgxRksrOAhArSUX_LP0NLMxXDGP0TGwx218QgNW4qj6OxQZrBCO5YRl0Lb-mQVZZ2L3AQXk39gvArTnqIQ8aV9hwLeiBqq1qZU7Q77RUHI-yMUfkH3FAy2xQS1AIn7-rM6rCXtjXVUzdjm1_6HrJkDjS20HUFsaqmKacPxlkkCFa08zxsIsuU_h9LY4VdeVHJKnvWUFWy2M6jYvKIJRuF0Dk1PCTLqbiBUmyCnr20qGe5Y8Vc9c3pvuudm6hdk6aGa3zuNOIzftPthPEoUzoG4qZ3c
       - REDIS_HOSTS=alice-redis:6379
       - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"] # FIXME
+      test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -243,11 +271,92 @@ services:
       - alice
     restart: always
 
+  alice-privacy:
+    image: provide/privacy
+    container_name: alice-privacy
+    depends_on:
+      - alice-nats-streaming
+      - alice-postgres
+      - alice-privacy-consumer
+      - alice-redis
+      - alice-vault
+    environment:
+      - DATABASE_HOST=alice-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=alice-privacy
+      - NATS_URL=nats://alice-nats:4222
+      - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - PORT=8080
+      - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://alice-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: alice-privacy
+    networks:
+      - alice
+    ports:
+      - 8084:8080
+    restart: always
+
+  alice-privacy-consumer:
+    image: provide/privacy
+    entrypoint: ./ops/run_consumer.sh
+    container_name: alice-privacy-consumer
+    depends_on:
+      - alice-nats-streaming
+      - alice-postgres
+      - alice-redis
+      - alice-vault
+    environment:
+      - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
+      - DATABASE_HOST=alice-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=alice-privacy-consumer
+      - NATS_URL=nats://alice-nats:4222
+      - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://alice-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: alice-privacy-consumer
+    networks:
+      - alice
+    restart: always
+
   alice-statsdaemon:
     image: provide/nchain
     entrypoint: ./ops/run_statsdaemon.sh
     container_name: alice-statsdaemon
     depends_on:
+      - alice-ident
       - alice-nats-streaming
       - alice-postgres
       - alice-redis
@@ -256,14 +365,21 @@ services:
       - DATABASE_NAME=nchain_dev
       - DATABASE_USER=nchain
       - DATABASE_PASSWORD=nchain
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=statsdaemon
       - NATS_URL=nats://alice-nats:4222
       - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - PAYMENTS_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImU2OmY3OmQ1OjI0OmUyOjU5OjA2OjJiOmJjOmEyOjhjOjM1OjlkOmNhOjBhOjg3IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjAwNzA5Njg3LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiJkMDIzM2JlZC1iMThkLTRmNGEtODNlYS02MjBmYjdjYTY0NWMiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4wYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJuZXR3b3JrLiouY29ubmVjdG9yLioiLCJuZXR3b3JrLiouc3RhdHVzIiwicGxhdGZvcm0uXHUwMDNlIl19fX0sInBydmQiOnsiYXBwbGljYXRpb25faWQiOiIwYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJleHRlbmRlZCI6eyJwZXJtaXNzaW9ucyI6eyIqIjo1MTB9fSwicGVybWlzc2lvbnMiOjUxMH0sInN1YiI6ImFwcGxpY2F0aW9uOjBjNWE5ZmViLTE2MGMtNGZlMS05MTBlLTE4NzQyZjg2NGJjZSJ9.SUd50x0g6opm2oU9zFMu6rLpc-22WeEi50OByzluBsoV1fCN1INzqHnCJAMLC2myXIDRKaP1Q-MZVAw97hpzuGQjXEY8yobX0Br3DjGADqaM3iJiaD4GB73lZtd2w2jAsy3PDfvEE_dd9SalGA90WLoSUwkEObFxqufj2vnMVuiH1UwUnMawuVGfZPzZ7Wtoe9K4sq0E7qYiND5lgz0tyDnP7FWyd_wHEwjan_AhabgUJA0w5XlUq7AnjHe-NTrCzU_ZTJ6Hdvxy_uNRSOOv4fV4_MVRomqPePBTPXeeLBpjpsVVKSsKGrP3z7oAWclCm21i-9hEvyEeIN3TV71KgYDLaMtHsHZYPdo1WaKdnq49uPVgXbzCsAAWvgjKbOT62VciQVgv1ognm_22gPgxRksrOAhArSUX_LP0NLMxXDGP0TGwx218QgNW4qj6OxQZrBCO5YRl0Lb-mQVZZ2L3AQXk39gvArTnqIQ8aV9hwLeiBqq1qZU7Q77RUHI-yMUfkH3FAy2xQS1AIn7-rM6rCXtjXVUzdjm1_6HrJkDjS20HUFsaqmKacPxlkkCFa08zxsIsuU_h9LY4VdeVHJKnvWUFWy2M6jYvKIJRuF0Dk1PCTLqbiBUmyCnr20qGe5Y8Vc9c3pvuudm6hdk6aGa3zuNOIzftPthPEoUzoG4qZ3c
       - REDIS_HOSTS=alice-redis:6379
       - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=corn domain lonely owner media grape hard rough arena knock uncover goddess cinnamon wing actress spring dizzy skill alter pistol funny bind rapid soap
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"] # FIXME
+      test: ["CMD", "curl", "-f", "http://alice-nchain:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -285,6 +401,7 @@ services:
       - DATABASE_PASSWORD=vault
       - LOG_LEVEL=DEBUG
       - PORT=8080
+      - SEAL_UNSEAL_VALIDATION_HASH=0x05598175ac56c919ca39be16fdbb4335f755e53c27aca03717dc1b89e206aad1
       - SYSLOG_ENDPOINT=splunk:8514
     healthcheck:
       test: ["CMD", "curl", "-f", "http://alice-vault:8080/status"]
@@ -299,35 +416,177 @@ services:
       - 8082:8080
     restart: always
 
-  alice-nethermind:
-    image: provide/nethermind
-    container_name: alice-nethermind
+  alice-proxy:
+    image: provide/baseline
+    container_name: alice-proxy
+    entrypoint: ./ops/run_api.sh
+    depends_on:
+      - alice-nats-streaming
+      - alice-postgres
+      - alice-redis
+      - alice-privacy
     environment:
-      - NETHERMIND_CONFIG=baseline
-      - NETHERMIND_INITCONFIG_STATICNODESPATH=Data/static-nodes-baseline-hosts.json
-      - NETHERMIND_JSONRPCCONFIG_ENABLED=true
-      - NETHERMIND_JSONRPCCONFIG_HOST=0.0.0.0
-      - NETHERMIND_JSONRPCCONFIG_PORT=8522
-      - NETHERMIND_KEYSTORECONFIG_TESTNODEKEY=020102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
-      - NETHERMIND_NETWORKCONFIG_DISCOVERYPORT=30222
-      - NETHERMIND_NETWORKCONFIG_P2PPORT=30222
-      - NETHERMIND_SYNCCONFIG_FASTSYNC=false
+      - BASELINE_ORGANIZATION_ADDRESS=
+      - BASELINE_REGISTRY_CONTRACT_ADDRESS=
+      - DATABASE_HOST=alice-postgres
+      - DATABASE_NAME=providibright_dev
+      - DATABASE_USER=providibright
+      - DATABASE_PASSWORD=providibright
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=alice-proxy
+      - NATS_URL=nats://alice-nats:4222
+      - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - NCHAIN_API_HOST=alice-nchain:8080
+      - NCHAIN_API_SCHEME=http
+      - NCHAIN_BASELINE_NETWORK_ID=
+      - PRIVACY_API_HOST=alice-privacy:8080
+      - PRIVACY_API_SCHEME=http
+      - PROVIDE_ORGANIZATION_ID=
+      - PROVIDE_ORGANIZATION_REFRESH_TOKEN=
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+      - REDIS_HOSTS=alice-redis:6379
+      - SYSLOG_ENDPOINT=splunk:8514
     healthcheck:
-      test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:8522"]
+      test: ["CMD", "curl", "-f", "http://alice-proxy:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
       start_period: 10s
-    hostname: alice-nethermind
+    hostname: alice-proxy
     networks:
       - alice
-      - bob
     ports:
-      - 8522:8522
-      - 30222:30222
+      - 8088:8080
     restart: always
+
+  alice-proxy-consumer:
+    image: provide/baseline
+    container_name: alice-proxy-consumer
+    entrypoint: ./ops/run_consumer.sh
+    depends_on:
+      - alice-nats-streaming
+      - alice-postgres
+      - alice-redis
+    environment:
+      - BASELINE_ORGANIZATION_ADDRESS=
+      - BASELINE_REGISTRY_CONTRACT_ADDRESS=
+      - DATABASE_HOST=alice-postgres
+      - DATABASE_NAME=providibright_dev
+      - DATABASE_USER=providibright
+      - DATABASE_PASSWORD=providibright
+      - IDENT_API_HOST=alice-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=alice-proxy
+      - NATS_URL=nats://alice-nats:4222
+      - NATS_STREAMING_URL=nats://alice-nats-streaming:4222
+      - NCHAIN_API_HOST=alice-nchain:8080
+      - NCHAIN_API_SCHEME=http
+      - NCHAIN_BASELINE_NETWORK_ID=
+      - PRIVACY_API_HOST=alice-privacy:8080
+      - PRIVACY_API_SCHEME=http
+      - PROVIDE_ORGANIZATION_ID=
+      - PROVIDE_ORGANIZATION_REFRESH_TOKEN=
+      - VAULT_API_HOST=alice-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+      - REDIS_HOSTS=alice-redis:6379
+      - SYSLOG_ENDPOINT=splunk:8514
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://alice-proxy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: alice-proxy-consumer
+    networks:
+      - alice
+    restart: always
+
+  # splunk stack
+
+  splunk:
+    image: splunk/splunk:latest
+    container_name: splunk
+    hostname: splunk
+    environment:
+      - SPLUNK_START_ARGS=--accept-license
+      - SPLUNK_HEC_TOKEN=11111111-1111-1111-1111-1111111111113
+      - SPLUNK_PASSWORD=changeme
+      - SPLUNK_APPS_URL=https://github.com/splunk/ethereum-basics/releases/download/latest/ethereum-basics.tgz
+    expose:
+      - 8000
+      - 8090
+      - 8514
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000']
+      interval: 5s
+      timeout: 5s
+      retries: 2
+    ports:
+      - 8000:8000
+      - 8090:8088
+      - 8514:8514
     volumes:
-      - ./ops/await_tcp.sh:/usr/local/bin/await_tcp.sh:cached
+      - splunk-var:/opt/splunk/var
+      - splunk-etc:/opt/splunk/etc
+      - ./splunk-config.yml:/tmp/defaults/default.yml
+      - ./dashboards:/opt/splunk/etc/apps/search/local/data/ui/views/
+    networks:
+      - alice
+
+  alice-ethlogger:
+    container_name: alice-ethlogger
+    image: splunkdlt/ethlogger:latest
+    environment:
+      - ETH_RPC_URL=http://kovan.poa.network:8888
+      - NETWORK_NAME=ropsten
+      - START_AT_BLOCK=latest
+      - SPLUNK_HEC_URL=https://splunk:8088
+      - SPLUNK_HEC_TOKEN=11111111-1111-1111-1111-1111111111113
+      - SPLUNK_EVENTS_INDEX=main
+      - SPLUNK_METRICS_INDEX=eth_metrics
+      - SPLUNK_INTERNAL_INDEX=eth_metrics
+      - SPLUNK_HEC_REJECT_INVALID_CERTS=false
+      - ABI_DIR=/app/abis
+      - COLLECT_PENDING_TX=true
+      - COLLECT_PEER_INFO=true
+      - DEBUG=ethlogger:abi:*
+    depends_on:
+      - splunk
+    restart: unless-stopped
+    hostname: alice-ethlogger
+    volumes:
+      - ./abis:/app/abis:ro
+      - ./ops/splunk/alice-ethlogger:/app
+    networks:
+      - alice
+    logging: *splunk-logging
+
+  cadvisor:
+    image: google/cadvisor:latest
+    command:
+      - --storage_driver=statsd
+      - --storage_driver_host=splunk:8125
+      - --docker_only=true
+    depends_on:
+      - splunk
+    user: root
+    hostname: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - alice
+    logging: *splunk-logging
 
   # bob
 
@@ -338,7 +597,6 @@ services:
       - POSTGRES_DB=prvd
       - POSTGRES_USER=prvd
       - POSTGRES_PASSWORD=prvdp455
-      - SYSLOG_ENDPOINT=splunk:8514
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "prvd", "-d", "prvd"]
       interval: 1m
@@ -371,7 +629,7 @@ services:
   bob-nats:
     image: provide/nats-server
     container_name: bob-provide-nats
-    command: ["-auth", "testtoken", "-p", "4222", "--remote_syslog", "udp://splunk:8514", "-D", "-V"]
+    command: ["-auth", "testtoken", "-p", "4222", "-D", "-V"]
     environment:
       JWT_SIGNER_PUBLIC_KEY: |-
         -----BEGIN PUBLIC KEY-----
@@ -389,7 +647,7 @@ services:
         PUl1cxrvY7BHh4obNa6Bf8ECAwEAAQ==
         -----END PUBLIC KEY-----
     healthcheck:
-      test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:4224"]
+      test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:4222"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -410,8 +668,6 @@ services:
     container_name: bob-nats-streaming
     depends_on:
       - bob-nats
-    environment:
-      - SYSLOG_ENDPOINT=splunk:8514
     healthcheck:
       test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:4222"]
       interval: 1m
@@ -432,6 +688,7 @@ services:
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
+      - bob-vault
     environment:
       - DATABASE_HOST=bob-postgres
       - DATABASE_NAME=ident_dev
@@ -443,7 +700,10 @@ services:
       - REDIS_HOSTS=bob-redis:6379
       - LOG_LEVEL=DEBUG
       - PORT=8080
-      - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-ident:8080/status"]
       interval: 1m
@@ -465,6 +725,7 @@ services:
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
+      - bob-vault
     environment:
       - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
       - DATABASE_HOST=bob-postgres
@@ -475,12 +736,15 @@ services:
       - NATS_CLIENT_PREFIX=bob-ident-consumer
       - NATS_URL=nats://bob-nats:4222
       - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - NCHAIN_API_HOST=bob-nchain:8080
+      - NCHAIN_API_SCHEME=http
       - REDIS_HOSTS=bob-redis:6379
-      - SYSLOG_ENDPOINT=splunk:8514
-      - VAULT_API_SCHEME=http
       - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://bob-ident:8080/status"] # FIXME
+      test: ["CMD", "curl", "-f", "http://bob-ident:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -494,6 +758,7 @@ services:
     image: provide/nchain
     container_name: bob-nchain
     depends_on:
+      - bob-ident
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
@@ -502,13 +767,19 @@ services:
       - DATABASE_NAME=nchain_dev
       - DATABASE_USER=nchain
       - DATABASE_PASSWORD=nchain
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=bob-nchain
       - NATS_URL=nats://bob-nats:4222
       - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - PAYMENTS_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImU2OmY3OmQ1OjI0OmUyOjU5OjA2OjJiOmJjOmEyOjhjOjM1OjlkOmNhOjBhOjg3IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjAwNzA5NzU0LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiJjN2I2YzI2ZS00OTkwLTQ4YWYtYmMwYy05YWRiY2E5ZmRmNzYiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4wMTU1NGUyMi0zZDdhLTQ0YTMtOWM2NS02YmNhYmFhMDhjMzgiLCJuZXR3b3JrLiouY29ubmVjdG9yLioiLCJuZXR3b3JrLiouc3RhdHVzIiwicGxhdGZvcm0uXHUwMDNlIl19fX0sInBydmQiOnsiYXBwbGljYXRpb25faWQiOiIwMTU1NGUyMi0zZDdhLTQ0YTMtOWM2NS02YmNhYmFhMDhjMzgiLCJleHRlbmRlZCI6eyJwZXJtaXNzaW9ucyI6eyIqIjo1MTB9fSwicGVybWlzc2lvbnMiOjUxMH0sInN1YiI6ImFwcGxpY2F0aW9uOjAxNTU0ZTIyLTNkN2EtNDRhMy05YzY1LTZiY2FiYWEwOGMzOCJ9.iPYYSS0hHNYLUXcgpBfQbo6goMGDHF5Oxv1OvkB-WAzRgZSAm2HFroOUsmPlCQwO5eNeTfMqRaQMDdl6idTCip99y-zYTu8ys7dahyk4P1lhh4BB8vTCl3AHQuyUTGloMrY2JytpkmXMZTsxu-UhQxaaQN0IlSotSIFAYPT3jHH5nYy2MJbcfxePt8xKmXzwvpjTEVJRmUfAfEXjJF34S3hAuw9S7WncKucZfuP1WwP65h53HbLB69DR6KFZ76eiRavke5RpT40r9UKC6zPP-UZhTAuWQjOSmBhkd_IUg4T2a8r4W9CJT6aLgtwE0i1OUrPDVj_EzQV9tsjlwIOv5y9r_p-sfdxXdHFfoT8nAs5uIcWTw45J2Ycc0b4vqs-sYDr2qn7TS5DvJbPQSnRBS9YZ8CJq9mFpc5GjunCzEqO6JkvEWaN1mqPJbcvMGmLRQt5zA-2D0fFq1mvIUCUcg3EQ5J5lAZqudGf9mnYf4xRIMacCssF5VsP36xXg7pnscqh3u3JdQ-Fon3nB5vbIXn2fxaJjYl4ggNr-IgLxK7_h9KlDkiv7I7EKWGl2Np0q3-mVvuTIk7M-GqT3Dx9TtpR6MsK6EX0frUH3bZH8RHBHnxx67oxNMamviT-XUNudUU7Wan1PfnaPSsqfrn6OT5Abep-BbewKJn3ErY0Z-oU
       - PORT=8080
       - REDIS_HOSTS=bob-redis:6379
-      - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"]
       interval: 1m
@@ -527,6 +798,7 @@ services:
     entrypoint: ./ops/run_consumer.sh
     container_name: bob-nchain-consumer
     depends_on:
+      - bob-ident
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
@@ -536,16 +808,21 @@ services:
       - DATABASE_NAME=nchain_dev
       - DATABASE_USER=nchain
       - DATABASE_PASSWORD=nchain
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=bob-nchain-consumer
       - NATS_URL=nats://bob-nats:4222
       - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
       - NATS_TOKEN=testtoken
-      - PORT=8080
+      - PAYMENTS_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImU2OmY3OmQ1OjI0OmUyOjU5OjA2OjJiOmJjOmEyOjhjOjM1OjlkOmNhOjBhOjg3IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjAwNzA5NzU0LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiJjN2I2YzI2ZS00OTkwLTQ4YWYtYmMwYy05YWRiY2E5ZmRmNzYiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4wMTU1NGUyMi0zZDdhLTQ0YTMtOWM2NS02YmNhYmFhMDhjMzgiLCJuZXR3b3JrLiouY29ubmVjdG9yLioiLCJuZXR3b3JrLiouc3RhdHVzIiwicGxhdGZvcm0uXHUwMDNlIl19fX0sInBydmQiOnsiYXBwbGljYXRpb25faWQiOiIwMTU1NGUyMi0zZDdhLTQ0YTMtOWM2NS02YmNhYmFhMDhjMzgiLCJleHRlbmRlZCI6eyJwZXJtaXNzaW9ucyI6eyIqIjo1MTB9fSwicGVybWlzc2lvbnMiOjUxMH0sInN1YiI6ImFwcGxpY2F0aW9uOjAxNTU0ZTIyLTNkN2EtNDRhMy05YzY1LTZiY2FiYWEwOGMzOCJ9.iPYYSS0hHNYLUXcgpBfQbo6goMGDHF5Oxv1OvkB-WAzRgZSAm2HFroOUsmPlCQwO5eNeTfMqRaQMDdl6idTCip99y-zYTu8ys7dahyk4P1lhh4BB8vTCl3AHQuyUTGloMrY2JytpkmXMZTsxu-UhQxaaQN0IlSotSIFAYPT3jHH5nYy2MJbcfxePt8xKmXzwvpjTEVJRmUfAfEXjJF34S3hAuw9S7WncKucZfuP1WwP65h53HbLB69DR6KFZ76eiRavke5RpT40r9UKC6zPP-UZhTAuWQjOSmBhkd_IUg4T2a8r4W9CJT6aLgtwE0i1OUrPDVj_EzQV9tsjlwIOv5y9r_p-sfdxXdHFfoT8nAs5uIcWTw45J2Ycc0b4vqs-sYDr2qn7TS5DvJbPQSnRBS9YZ8CJq9mFpc5GjunCzEqO6JkvEWaN1mqPJbcvMGmLRQt5zA-2D0fFq1mvIUCUcg3EQ5J5lAZqudGf9mnYf4xRIMacCssF5VsP36xXg7pnscqh3u3JdQ-Fon3nB5vbIXn2fxaJjYl4ggNr-IgLxK7_h9KlDkiv7I7EKWGl2Np0q3-mVvuTIk7M-GqT3Dx9TtpR6MsK6EX0frUH3bZH8RHBHnxx67oxNMamviT-XUNudUU7Wan1PfnaPSsqfrn6OT5Abep-BbewKJn3ErY0Z-oU
       - REDIS_HOSTS=bob-redis:6379
-      - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"] # FIXME
+      test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -555,11 +832,90 @@ services:
       - bob
     restart: always
 
+  bob-privacy:
+    image: provide/privacy
+    container_name: bob-privacy
+    depends_on:
+      - bob-nats-streaming
+      - bob-postgres
+      - bob-privacy-consumer
+      - bob-redis
+      - bob-vault
+    environment:
+      - DATABASE_HOST=bob-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=bob-privacy
+      - NATS_URL=nats://bob-nats:4222
+      - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - PORT=8080
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://bob-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: bob-privacy
+    networks:
+      - bob
+    ports:
+      - 8087:8080
+    restart: always
+
+  bob-privacy-consumer:
+    image: provide/privacy
+    entrypoint: ./ops/run_consumer.sh
+    container_name: bob-privacy-consumer
+    depends_on:
+      - bob-nats-streaming
+      - bob-postgres
+      - bob-redis
+      - bob-vault
+    environment:
+      - CONSUME_NATS_STREAMING_SUBSCRIPTIONS=true
+      - DATABASE_HOST=bob-postgres
+      - DATABASE_NAME=privacy_dev
+      - DATABASE_USER=privacy
+      - DATABASE_PASSWORD=privacy
+      - DATABASE_SUPERUSER=prvd
+      - DATABASE_SUPERUSER_PASSWORD=prvdp455
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=bob-privacy-consumer
+      - NATS_URL=nats://bob-nats:4222
+      - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://bob-privacy:8080/status"]
+      interval: 1m
+      timeout: 1s
+      retries: 2
+      start_period: 10s
+    hostname: bob-privacy-consumer
+    networks:
+      - bob
+    restart: always
+
   bob-statsdaemon:
     image: provide/nchain
     entrypoint: ./ops/run_statsdaemon.sh
     container_name: bob-statsdaemon
     depends_on:
+      - bob-ident
       - bob-nats-streaming
       - bob-postgres
       - bob-redis
@@ -568,14 +924,20 @@ services:
       - DATABASE_NAME=nchain_dev
       - DATABASE_USER=nchain
       - DATABASE_PASSWORD=nchain
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
       - LOG_LEVEL=DEBUG
       - NATS_CLIENT_PREFIX=statsdaemon
       - NATS_URL=nats://bob-nats:4222
       - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - PAYMENTS_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6ImU2OmY3OmQ1OjI0OmUyOjU5OjA2OjJiOmJjOmEyOjhjOjM1OjlkOmNhOjBhOjg3IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjAwNzA5Njg3LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiJkMDIzM2JlZC1iMThkLTRmNGEtODNlYS02MjBmYjdjYTY0NWMiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4wYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJuZXR3b3JrLiouY29ubmVjdG9yLioiLCJuZXR3b3JrLiouc3RhdHVzIiwicGxhdGZvcm0uXHUwMDNlIl19fX0sInBydmQiOnsiYXBwbGljYXRpb25faWQiOiIwYzVhOWZlYi0xNjBjLTRmZTEtOTEwZS0xODc0MmY4NjRiY2UiLCJleHRlbmRlZCI6eyJwZXJtaXNzaW9ucyI6eyIqIjo1MTB9fSwicGVybWlzc2lvbnMiOjUxMH0sInN1YiI6ImFwcGxpY2F0aW9uOjBjNWE5ZmViLTE2MGMtNGZlMS05MTBlLTE4NzQyZjg2NGJjZSJ9.SUd50x0g6opm2oU9zFMu6rLpc-22WeEi50OByzluBsoV1fCN1INzqHnCJAMLC2myXIDRKaP1Q-MZVAw97hpzuGQjXEY8yobX0Br3DjGADqaM3iJiaD4GB73lZtd2w2jAsy3PDfvEE_dd9SalGA90WLoSUwkEObFxqufj2vnMVuiH1UwUnMawuVGfZPzZ7Wtoe9K4sq0E7qYiND5lgz0tyDnP7FWyd_wHEwjan_AhabgUJA0w5XlUq7AnjHe-NTrCzU_ZTJ6Hdvxy_uNRSOOv4fV4_MVRomqPePBTPXeeLBpjpsVVKSsKGrP3z7oAWclCm21i-9hEvyEeIN3TV71KgYDLaMtHsHZYPdo1WaKdnq49uPVgXbzCsAAWvgjKbOT62VciQVgv1ognm_22gPgxRksrOAhArSUX_LP0NLMxXDGP0TGwx218QgNW4qj6OxQZrBCO5YRl0Lb-mQVZZ2L3AQXk39gvArTnqIQ8aV9hwLeiBqq1qZU7Q77RUHI-yMUfkH3FAy2xQS1AIn7-rM6rCXtjXVUzdjm1_6HrJkDjS20HUFsaqmKacPxlkkCFa08zxsIsuU_h9LY4VdeVHJKnvWUFWy2M6jYvKIJRuF0Dk1PCTLqbiBUmyCnr20qGe5Y8Vc9c3pvuudm6hdk6aGa3zuNOIzftPthPEoUzoG4qZ3c
       - REDIS_HOSTS=bob-redis:6379
-      - SYSLOG_ENDPOINT=splunk:8514
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"] # FIXME
+      test: ["CMD", "curl", "-f", "http://bob-nchain:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
@@ -597,7 +959,7 @@ services:
       - DATABASE_PASSWORD=vault
       - LOG_LEVEL=DEBUG
       - PORT=8080
-      - SYSLOG_ENDPOINT=splunk:8514
+      - SEAL_UNSEAL_VALIDATION_HASH=0x1c1381fd075f1ee3d42799bb8da0602a2afb9ef4b492bf1eae72399ecc81b0f0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://bob-vault:8080/status"]
       interval: 1m
@@ -611,147 +973,96 @@ services:
       - 8083:8080
     restart: always
 
-  bob-nethermind:
-    image: provide/nethermind
-    container_name: bob-nethermind
+  bob-proxy:
+    image: provide/baseline
+    container_name: bob-proxy
+    entrypoint: ./ops/run_api.sh
+    depends_on:
+      - bob-nats-streaming
+      - bob-postgres
+      - bob-redis
+      - bob-privacy
     environment:
-      - NETHERMIND_CONFIG=baseline
-      - NETHERMIND_INITCONFIG_STATICNODESPATH=Data/static-nodes-baseline-hosts.json
-      - NETHERMIND_JSONRPCCONFIG_ENABLED=true
-      - NETHERMIND_JSONRPCCONFIG_HOST=0.0.0.0
-      - NETHERMIND_JSONRPCCONFIG_PORT=8511
-      - NETHERMIND_KEYSTORECONFIG_TESTNODEKEY=120102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
-      - NETHERMIND_NETWORKCONFIG_DISCOVERYPORT=30111
-      - NETHERMIND_NETWORKCONFIG_P2PPORT=30111
-      - NETHERMIND_SYNCCONFIG_FASTSYNC=false
+      - BASELINE_ORGANIZATION_ADDRESS=
+      - BASELINE_REGISTRY_CONTRACT_ADDRESS=
+      - DATABASE_HOST=bob-postgres
+      - DATABASE_NAME=providibright_dev
+      - DATABASE_USER=providibright
+      - DATABASE_PASSWORD=providibright
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=bob-proxy
+      - NATS_URL=nats://bob-nats:4222
+      - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - NCHAIN_API_HOST=bob-nchain:8080
+      - NCHAIN_API_SCHEME=http
+      - NCHAIN_BASELINE_NETWORK_ID=
+      - PRIVACY_API_HOST=bob-privacy:8080
+      - PRIVACY_API_SCHEME=http
+      - PROVIDE_ORGANIZATION_ID=
+      - PROVIDE_ORGANIZATION_REFRESH_TOKEN=
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+      - REDIS_HOSTS=bob-redis:6379
     healthcheck:
-      test: ["CMD", "/usr/local/bin/await_tcp.sh", "localhost:8511"]
+      test: ["CMD", "curl", "-f", "http://bob-proxy:8080/status"]
       interval: 1m
       timeout: 1s
       retries: 2
       start_period: 10s
-    hostname: bob-nethermind
+    hostname: bob-proxy
     networks:
-      - alice
       - bob
     ports:
-      - 8511:8511
-      - 30111:30111
+      - 8089:8080
     restart: always
-    volumes:
-      - ./ops/await_tcp.sh:/usr/local/bin/await_tcp.sh:cached
 
-  # splunk stack
-
-  splunk:
-    image: splunk/splunk:latest
-    container_name: splunk
-    hostname: splunk
+  bob-proxy-consumer:
+    image: provide/baseline
+    container_name: bob-proxy-consumer
+    entrypoint: ./ops/run_consumer.sh
+    depends_on:
+      - bob-nats-streaming
+      - bob-postgres
+      - bob-redis
     environment:
-      - SPLUNK_START_ARGS=--accept-license
-      - SPLUNK_HEC_TOKEN=11111111-1111-1111-1111-1111111111113
-      - SPLUNK_PASSWORD=changeme
-      - SPLUNK_APPS_URL=https://github.com/splunk/ethereum-basics/releases/download/latest/ethereum-basics.tgz
-    expose:
-      - "8000"
-      - "8088"
+      - BASELINE_ORGANIZATION_ADDRESS=
+      - BASELINE_REGISTRY_CONTRACT_ADDRESS=
+      - DATABASE_HOST=bob-postgres
+      - DATABASE_NAME=providibright_dev
+      - DATABASE_USER=providibright
+      - DATABASE_PASSWORD=providibright
+      - IDENT_API_HOST=bob-ident:8080
+      - IDENT_API_SCHEME=http
+      - LOG_LEVEL=DEBUG
+      - NATS_CLIENT_PREFIX=bob-proxy
+      - NATS_URL=nats://bob-nats:4222
+      - NATS_STREAMING_URL=nats://bob-nats-streaming:4222
+      - NCHAIN_API_HOST=bob-nchain:8080
+      - NCHAIN_API_SCHEME=http
+      - NCHAIN_BASELINE_NETWORK_ID=
+      - PRIVACY_API_HOST=bob-privacy:8080
+      - PRIVACY_API_SCHEME=http
+      - PROVIDE_ORGANIZATION_ID=
+      - PROVIDE_ORGANIZATION_REFRESH_TOKEN=
+      - VAULT_API_HOST=bob-vault:8080
+      - VAULT_API_SCHEME=http
+      - VAULT_REFRESH_TOKEN=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwOjJlOmQ5OmUxOmI4OmEyOjM0OjM3Ojk5OjNhOjI0OmZjOmFhOmQxOmM4OjU5IiwidHlwIjoiSldUIn0.eyJhdWQiOiJodHRwczovL3Byb3ZpZGUuc2VydmljZXMvYXBpL3YxIiwiaWF0IjoxNjA1NzkxMjQ4LCJpc3MiOiJodHRwczovL2lkZW50LnByb3ZpZGUuc2VydmljZXMiLCJqdGkiOiI5YjUxNGIxNS01NTdlLTRhYWQtYTcwOC0wMTcwZTAwZWE1ZmIiLCJuYXRzIjp7InBlcm1pc3Npb25zIjp7InN1YnNjcmliZSI6eyJhbGxvdyI6WyJhcHBsaWNhdGlvbi4zNjAxNTdmOC1kNWExLTQ0NDAtOTE4Yi1mNjhiYjM5YzBkODAiLCJ1c2VyLjIzY2MwN2UwLTM4NTEtNDBkZC1iNjc1LWRmNzY4MDY3MmY3ZCIsIm5ldHdvcmsuKi5jb25uZWN0b3IuKiIsIm5ldHdvcmsuKi5zdGF0dXMiLCJwbGF0Zm9ybS5cdTAwM2UiXX19fSwicHJ2ZCI6eyJhcHBsaWNhdGlvbl9pZCI6IjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCIsImV4dGVuZGVkIjp7InBlcm1pc3Npb25zIjp7IioiOjUxMH19LCJwZXJtaXNzaW9ucyI6NTEwLCJ1c2VyX2lkIjoiMjNjYzA3ZTAtMzg1MS00MGRkLWI2NzUtZGY3NjgwNjcyZjdkIn0sInN1YiI6ImFwcGxpY2F0aW9uOjM2MDE1N2Y4LWQ1YTEtNDQ0MC05MThiLWY2OGJiMzljMGQ4MCJ9.SUh84MKBNstdu3KFu1zEAQq03xbPw1D0lLXeogz1HfBJy77bIGf7HLvCuc6bjkh0xj3cEuEus1dC1Dj3BvlZoSXsvz_biTzSapkXzJjpkwOL6qkYDmqTPZvXwqmk-mUNrHTPkqdiIJL7xA46tzHW3E_hjSA9HjEk1kXjPdJQ6_ifkgWNoAaSD--kudIrhZ7vLnfy0H1JEAOsXzSAMoc5_pNG2n79m0ywvb_4l9BqdsHW8N3xSQOFjcp9gD_tqo6ffug3pkpoy-RSguM_OaMR2lj_CHhYxAt0phtjUceDD3K1h5iZ38kSl7izhOdULMmGBhVpBMoSy6_R6ZzpCL3pj8FcReX9RXR5oYpm8PDtlmWqblQzjwY00-uYLfOX0_iS4MGfEsjadZPfTmJLcOTYC7H4PL9ZRu_XtMDUrGBQQz5b_ad2ZzMXbBNeU6vbxVKDG8VFKWOHAemqHTcvuOAsOCLIqOu-eJpZHlXbx-FXPTYledd-GBDe7IjaC9ll_JK3utCOnCq0qUs6lnXIrQ_Sp1LcTKJJ7aY5f9TxeoAuL-ghDbQ3Xkw6huKyPCz2evOwVLwrB9ZRMlQXgmTnB1OeQvWii1WbmkyV1Zhbz_RPB8ckK7_mFxuPvsXK8wTFiWFmj96sRX470kV-ooSfM5CzKZhSLqgyyaUNC0VaCPq0uuE
+      - VAULT_SEAL_UNSEAL_KEY=forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock
+      - REDIS_HOSTS=bob-redis:6379
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8000']
-      interval: 5s
-      timeout: 5s
+      test: ["CMD", "curl", "-f", "http://bob-proxy:8080/status"]
+      interval: 1m
+      timeout: 1s
       retries: 2
-    ports:
-      - "8000:8000"
-      - "8088:8088"
-      - "8514:8514"
-    volumes:
-      - splunk-var:/opt/splunk/var
-      - splunk-etc:/opt/splunk/etc
-      - ./ops/splunk/splunk-config.yml:/tmp/defaults/default.yml
-      - ./ops/splunk/dashboards:/opt/splunk/etc/apps/search/local/data/ui/views/
+      start_period: 10s
+    hostname: bob-proxy-consumer
     networks:
-      - alice
       - bob
-
-  alice-ethlogger:
-    container_name: alice-ethlogger
-    image: splunkdlt/ethlogger:latest
-    environment:
-      - ETH_RPC_URL=http://alice-nethermind:8522
-      - NETWORK_NAME=ropsten
-      - START_AT_BLOCK=latest
-      - SPLUNK_HEC_URL=https://splunk:8088
-      - SPLUNK_HEC_TOKEN=11111111-1111-1111-1111-1111111111113
-      - SPLUNK_EVENTS_INDEX=main
-      - SPLUNK_METRICS_INDEX=eth_metrics
-      - SPLUNK_INTERNAL_INDEX=eth_metrics
-      - SPLUNK_HEC_REJECT_INVALID_CERTS=false
-      - ABI_DIR=/app/abis
-      - COLLECT_PENDING_TX=true
-      - COLLECT_PEER_INFO=true
-      - DEBUG=ethlogger:abi:*
-    depends_on:
-      - splunk
-      - alice-nethermind
-    restart: unless-stopped
-    hostname: alice-ethlogger
-    volumes:
-      - ./ops/splunk/abis:/app/abis
-      - ./ops/splunk:/app
-    networks:
-      - alice
-      - bob
-    logging: *splunk-logging
-
-  bob-ethlogger:
-    container_name: bob-ethlogger
-    image: splunkdlt/ethlogger:latest
-    environment:
-      - ETH_RPC_URL=http://bob-nethermind:8511
-      - NETWORK_NAME=ropsten
-      - START_AT_BLOCK=latest
-      - SPLUNK_HEC_URL=https://splunk:8088
-      - SPLUNK_HEC_TOKEN=11111111-1111-1111-1111-1111111111113
-      - SPLUNK_EVENTS_INDEX=main
-      - SPLUNK_METRICS_INDEX=eth_metrics
-      - SPLUNK_INTERNAL_INDEX=eth_metrics
-      - SPLUNK_HEC_REJECT_INVALID_CERTS=false
-      - ABI_DIR=/app/abis
-      - COLLECT_PENDING_TX=true
-      - COLLECT_PEER_INFO=true
-      - DEBUG=ethlogger:abi:*
-    depends_on:
-      - splunk
-      - bob-nethermind
-    restart: unless-stopped
-    hostname: bob-ethlogger
-    volumes:
-      - ./ops/splunk/abis:/app/abis
-      - ./ops/splunk:/app
-    networks:
-      - alice
-      - bob
-    logging: *splunk-logging
-
-  cadvisor:
-    image: google/cadvisor:latest
-    command:
-      - --storage_driver=statsd
-      - --storage_driver_host=splunk:8125
-      - --docker_only=true
-    depends_on:
-      - splunk
-    user: root
-    hostname: cadvisor
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    networks:
-      - alice
-      - bob
-    logging: *splunk-logging
+    restart: always
 
 networks:
   alice:

--- a/examples/bri-1/base-example/ops/splunk/ops/await_tcp.sh
+++ b/examples/bri-1/base-example/ops/splunk/ops/await_tcp.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+AWAIT_cmdname=${0##*/}
+
+echoerr() { if [[ $AWAIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $AWAIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $AWAIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$AWAIT_cmdname: waiting $AWAIT_TIMEOUT seconds for $AWAIT_HOST:$AWAIT_PORT"
+    else
+        echoerr "$AWAIT_cmdname: waiting for $AWAIT_HOST:$AWAIT_PORT without a timeout"
+    fi
+    AWAIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $AWAIT_ISBUSY -eq 1 ]]; then
+            nc -z $AWAIT_HOST $AWAIT_PORT
+            AWAIT_result=$?
+        else
+            (echo > /dev/tcp/$AWAIT_HOST/$AWAIT_PORT) >/dev/null 2>&1
+            AWAIT_result=$?
+        fi
+        if [[ $AWAIT_result -eq 0 ]]; then
+            AWAIT_end_ts=$(date +%s)
+            echoerr "$AWAIT_cmdname: $AWAIT_HOST:$AWAIT_PORT is available after $((AWAIT_end_ts - AWAIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $AWAIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $AWAIT_QUIET -eq 1 ]]; then
+        timeout $AWAIT_BUSYTIMEFLAG $AWAIT_TIMEOUT bash $0 --quiet --child --host=$AWAIT_HOST --port=$AWAIT_PORT --timeout=$AWAIT_TIMEOUT &
+    else
+        timeout $AWAIT_BUSYTIMEFLAG $AWAIT_TIMEOUT bash $0 --child --host=$AWAIT_HOST --port=$AWAIT_PORT --timeout=$AWAIT_TIMEOUT &
+    fi
+    AWAIT_PID=$!
+    trap "kill -INT -$AWAIT_PID" INT
+    wait $AWAIT_PID
+    AWAIT_RESULT=$?
+    if [[ $AWAIT_RESULT -ne 0 ]]; then
+        echoerr "$AWAIT_cmdname: timeout occurred after waiting $AWAIT_TIMEOUT seconds for $AWAIT_HOST:$AWAIT_PORT"
+    fi
+    return $AWAIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        AWAIT_hostport=(${1//:/ })
+        AWAIT_HOST=${AWAIT_hostport[0]}
+        AWAIT_PORT=${AWAIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        AWAIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        AWAIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        AWAIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        AWAIT_HOST="$2"
+        if [[ $AWAIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        AWAIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        AWAIT_PORT="$2"
+        if [[ $AWAIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        AWAIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        AWAIT_TIMEOUT="$2"
+        if [[ $AWAIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        AWAIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        AWAIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$AWAIT_HOST" == "" || "$AWAIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+AWAIT_TIMEOUT=${AWAIT_TIMEOUT:-15}
+AWAIT_STRICT=${AWAIT_STRICT:-0}
+AWAIT_CHILD=${AWAIT_CHILD:-0}
+AWAIT_QUIET=${AWAIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+AWAIT_TIMEOUT_PATH=$(type -p timeout)
+AWAIT_TIMEOUT_PATH=$(realpath $AWAIT_TIMEOUT_PATH 2>/dev/null || readlink -f $AWAIT_TIMEOUT_PATH)
+AWAIT_BUSYTIMEFLAG=""
+if [[ $AWAIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        AWAIT_ISBUSY=1
+else
+        AWAIT_ISBUSY=0
+fi
+
+if [[ $AWAIT_CHILD -gt 0 ]]; then
+    wait_for
+    AWAIT_RESULT=$?
+    exit $AWAIT_RESULT
+else
+    if [[ $AWAIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        AWAIT_RESULT=$?
+    else
+        wait_for
+        AWAIT_RESULT=$?
+    fi
+fi
+
+if [[ $AWAIT_CLI != "" ]]; then
+    if [[ $AWAIT_RESULT -ne 0 && $AWAIT_STRICT -eq 1 ]]; then
+        echoerr "$AWAIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $AWAIT_RESULT
+    fi
+    exec "${AWAIT_CLI[@]}"
+else
+    exit $AWAIT_RESULT
+fi

--- a/examples/bri-1/base-example/package-lock.json
+++ b/examples/bri-1/base-example/package-lock.json
@@ -94,21 +94,30 @@
       }
     },
     "@baseline-protocol/privacy": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@baseline-protocol/privacy/-/privacy-0.2.0.tgz",
-      "integrity": "sha512-9NplsWZEWo7yRyICQaZj5wnRrhI11iSYMAtzeZCWVpuMWC2VPzuRLhN8i9Hat9w4E/48Vsf1L6FW1JRS+38BRg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@baseline-protocol/privacy/-/privacy-1.0.0.tgz",
+      "integrity": "sha512-Yc/uGpfexrvR7qnMo6IvwDCfGuWxVvo+qWsVRhX/5GvNmsQrSP4pZQNbq7jdqiw0Foz5nVrmR71oEbyCl0P5EA==",
       "requires": {
+        "@baseline-protocol/types": "1.1.0",
         "@types/uuid": "^8.0.0",
         "big-integer": "^1.6.48",
         "hex-to-binary": "^1.0.1",
         "keccak": "^3.0.1",
+        "provide-js": "^1.5.1",
         "zokrates-js": "^1.0.25"
+      },
+      "dependencies": {
+        "@baseline-protocol/types": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@baseline-protocol/types/-/types-1.1.0.tgz",
+          "integrity": "sha512-hrWiGqvkhgM8vMaMABIxGbzyJlvCLJBbPcXJIrw2E+M5ieH1TgZGW0/EozXO/oeeepMlH9MaeU6Jlhalro/bqg=="
+        }
       }
     },
     "@baseline-protocol/types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@baseline-protocol/types/-/types-0.1.0.tgz",
-      "integrity": "sha512-+GyBTAFoOD1edgsRzzgQCCVjH5Pl16DGE1baAl0W0xSAeHH7dXVBlkEjmzFSo794jnajZQBi0gNiQgMjc0Ck1g=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@baseline-protocol/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-/eu9s1nlQGpWCxkEvQ43sk0QTav8BoKdAB1KZAqo6bu1SG1dMv2xcT99NkYmNP6z/OrRNmy5zW3nTR27EaKavA=="
     },
     "@dabh/diagnostics": {
       "version": "2.0.2",
@@ -301,17 +310,17 @@
       "integrity": "sha512-gUn7rBuCCmQlPGDK9hee6Pp0NRRAr2tsBOHN6YIv30L/ytZ2VHiCo1BtbQgoBesaMu3qK3/+GBhmpr2dd+YcXA=="
     },
     "@provide/types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@provide/types/-/types-0.3.0.tgz",
-      "integrity": "sha512-Wl7eK6zW4lsjRwXA74h1jBgZ988HdB8btgMHMLhq0no/PK+MvPjaDqWAmZ03cwZ8ih1GugA3OI/xrPZbRii7+A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@provide/types/-/types-1.2.5.tgz",
+      "integrity": "sha512-ASFu+09lFYcvghpPMYGc/7bw7Vvqmbwbv3oyzAlccBp/bjCoOYBG8q4gBd8CIdWW5vmj5DQi9BwxGKKhQLqKMQ==",
       "requires": {
         "ethers": "4.0.38"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.39.tgz",
-          "integrity": "sha512-dJLCxrpQmgyxYGcl0Ae9MTsQgI22qHHcGFj/8VKu7McJA5zQpnuGjoksnxbo1JxSjW/Nahnl13W8MYZf01CZHA=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "elliptic": {
           "version": "6.3.3",
@@ -870,6 +879,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "await-exec": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/await-exec/-/await-exec-0.1.2.tgz",
+      "integrity": "sha512-BQUiyBLScS0+YPnnCZZGjb78mZ8sQ8aKgxarDPNw05rpbaCS7VIQSLy2tgjZKct9Dn1xLbKMXOpA98OWei90zA=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1009,9 +1023,9 @@
       }
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1946,6 +1960,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -2238,6 +2253,7 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
       "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -2252,29 +2268,11 @@
         "string.prototype.trimstart": "^1.0.1"
       },
       "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
         "object.assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.18.0-next.0",
@@ -2286,6 +2284,7 @@
               "version": "1.18.0-next.1",
               "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
               "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "dev": true,
               "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
@@ -2338,6 +2337,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3163,9 +3163,9 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3310,7 +3310,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3495,6 +3496,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3513,7 +3515,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -3773,9 +3776,9 @@
       "dev": true
     },
     "ip-regex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
-      "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -3824,9 +3827,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -4011,7 +4014,8 @@
     "is-callable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
     },
     "is-circular": {
       "version": "1.0.2",
@@ -4047,7 +4051,8 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4127,7 +4132,8 @@
     "is-negative-zero": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -4164,6 +4170,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
       "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -4194,6 +4201,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -4257,9 +4265,9 @@
       }
     },
     "it-concat": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.2.tgz",
-      "integrity": "sha512-YZtXOe10qBcTDOsz59AscfmsKRoVPYX5AFxCans2L/QL20Jah1H1/+wzWDaJj8zu0KiA9gys3vBoZIZwhsUeeg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.3.tgz",
+      "integrity": "sha512-sjeZQ1BWQ9U/W2oI09kZgUyvSWzQahTkOkLIsnEPgyqZFaF9ME5gV6An4nMjlyhXKWQMKEakQU8oRHs2SdmeyA==",
       "requires": {
         "bl": "^4.0.0"
       }
@@ -5489,12 +5497,14 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6004,9 +6014,9 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
-      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.5.2.tgz",
+      "integrity": "sha512-LPzSaBYp/TcbuSlpGwqT5jR9kvJ3Zp5ic2N5c2ybx6XB/lSfEHq2D7ja8AgoxHoMD91wXFALJoXsvshKPuXyew=="
     },
     "protons": {
       "version": "1.2.1",
@@ -6020,19 +6030,34 @@
       }
     },
     "provide-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/provide-js/-/provide-js-1.3.5.tgz",
-      "integrity": "sha512-LQRUmtHmWgs+sIEWdD9DeTu/wau40jbl7792HioQoDrF2KJQGLOnc4mJ/OrQilbvDVo6G5QxapbTuiWVIK3aPw==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/provide-js/-/provide-js-1.6.11.tgz",
+      "integrity": "sha512-roRURLZuyBFPauoiGhJ2A5xhAIpTaT/G9lx3pj9JbHv99e0TP3oUPIztqknnrbIHbz2OMnzMNI+ors/1m5s8gw==",
       "requires": {
-        "@provide/types": "^0.3.0",
+        "@provide/types": "^1.2.5",
         "@types/jsonwebtoken": "^8.3.5",
         "@types/node": "^12.12.14",
-        "axios": "^0.19.2",
+        "axios": "^0.21.1",
         "ipfs-http-client": "^42.0.0",
         "jsonwebtoken": "^8.5.1",
         "mime-types": "^2.1.24",
         "serialize-javascript": "2.1.1",
         "ts-natsutil": "^1.0.7"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+          "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+        }
       }
     },
     "proxy-addr": {
@@ -6765,9 +6790,9 @@
       }
     },
     "solc": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.3.tgz",
-      "integrity": "sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.8.2.tgz",
+      "integrity": "sha512-fMfcAPaePLfsOY82jqONt0RMh5M8m+pK6QtnMGMUFUm8uEDlUmoqnyLxGVFelosJaVfXhygAB+mTlb+HxiV7DQ==",
       "requires": {
         "command-exists": "^1.2.8",
         "commander": "3.0.2",
@@ -7055,9 +7080,9 @@
       "dev": true
     },
     "stream-to-it": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
-      "integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
       "requires": {
         "get-iterator": "^1.0.2"
       }
@@ -7081,6 +7106,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -7090,6 +7116,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -8006,6 +8033,27 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+    },
+    "uuidv4": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.11.tgz",
+      "integrity": "sha512-OTS4waH9KplrXNADKo+Q1kT9AHWr8DaC0S5F54RQzEwcUaEzBEWQQlJyDUw/u1bkRhJyqkqhLD4M4lbFbV+89g==",
+      "requires": {
+        "@types/uuid": "8.3.1",
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "@types/uuid": {
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/examples/bri-1/base-example/package.json
+++ b/examples/bri-1/base-example/package.json
@@ -23,14 +23,16 @@
   "dependencies": {
     "@baseline-protocol/api": "0.2.0",
     "@baseline-protocol/messaging": "0.1.0",
-    "@baseline-protocol/privacy": "0.2.0",
-    "@baseline-protocol/types": "0.1.0",
+    "@baseline-protocol/privacy": "1.0.0",
+    "@baseline-protocol/types": "1.2.0",
+    "await-exec": "^0.1.2",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",
     "jsonwebtoken": "8.5.1",
     "loglevel": "^1.6.8",
-    "provide-js": "^1.3.5",
-    "solc": "^0.7.0",
+    "provide-js": "^1.6.11",
+    "solc": "^0.8.0",
+    "uuidv4": "^6.2.11",
     "zokrates-js": "1.0.25"
   },
   "devDependencies": {

--- a/examples/bri-1/base-example/src/index.ts
+++ b/examples/bri-1/base-example/src/index.ts
@@ -1,38 +1,52 @@
 import { IBaselineRPC, IBlockchainService, IRegistry, IVault, MerkleTreeNode, baselineServiceFactory, baselineProviderProvide } from '@baseline-protocol/api';
 import { IMessagingService, messagingProviderNats, messagingServiceFactory } from '@baseline-protocol/messaging';
-import { IZKSnarkCircuitProvider, IZKSnarkCompilationArtifacts, IZKSnarkTrustedSetupArtifacts, zkSnarkCircuitProviderServiceFactory, zkSnarkCircuitProviderServiceZokrates, Element, elementify, rndHex, concatenateThenHash } from '@baseline-protocol/privacy';
+import { zkSnarkCircuitProviderServiceFactory, zkSnarkCircuitProviderServiceProvide, Element, elementify, rndHex, concatenateThenHash } from '@baseline-protocol/privacy';
+import { ICircuitProver, ICircuitRegistry, ICircuitVerifier } from '@baseline-protocol/privacy/dist/cjs/zkp';
 import { Message as ProtocolMessage, Opcode, PayloadType, marshalProtocolMessage, unmarshalProtocolMessage } from '@baseline-protocol/types';
-import { Application as Workgroup, Invite, Vault as ProvideVault, Organization, Token, Key as VaultKey } from '@provide/types';
-import { Capabilities, Ident, NChain, Vault, capabilitiesFactory, nchainClientFactory } from 'provide-js';
-import { readFileSync } from 'fs';
+import { Application as Workgroup, Circuit, Invite, Vault as ProvideVault, Object as BaselineObject, Organization, Token, Key as VaultKey } from '@provide/types';
+import { Baseline, Capabilities, Ident, NChain, Vault, baselineClientFactory, capabilitiesFactory, nchainClientFactory } from 'provide-js';
 import { compile as solidityCompile } from 'solc';
 import * as jwt from 'jsonwebtoken';
 import * as log from 'loglevel';
 import { sha256 } from 'js-sha256';
 import { AuthService } from 'ts-natsutil';
+import { spawn, exec } from 'child_process';
 
-// const baselineDocumentCircuitPath = '../../../lib/circuits/createAgreement.zok';
-const baselineDocumentCircuitPath = '../../../lib/circuits/noopAgreement.zok';
-const baselineProtocolMessageSubject = 'baseline.inbound';
+import fs from 'fs';
 
-const zokratesImportResolver = (location, path) => {
-  let zokpath = `../../../lib/circuits/${path}`;
-  if (!zokpath.match(/\.zok$/i)) {
-    zokpath = `${zokpath}.zok`;
+const baselineProtocolMessageSubject = 'baseline.proxy';
+const baselineProtocolDefaultDomain = 'baseline.local';
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+class TryError extends Error {
+  promiseErrors: any[] = []
+}
+
+
+export const tryTimes = async <T>(prom: () => Promise<T>, times: number = 100000, wait: number = 500): Promise<T> => {
+  const errors : any[] = [];
+  for (let index = 0; index < times; index++) {
+    try {
+      return await prom()
+    } catch (err) { 
+      errors.push(err);
+    }
+    await sleep(wait);
   }
-  return {
-    source: readFileSync(zokpath).toString(),
-    location: path,
-  };
-};
+  const error = new TryError("Unfulfilled promises");
+  error.promiseErrors = errors;
+  throw error;
+}
 
 export class ParticipantStack {
-
   private baseline?: IBaselineRPC & IBlockchainService & IRegistry & IVault;
-  private baselineCircuitArtifacts?: IZKSnarkCompilationArtifacts;
-  private baselineCircuitSetupArtifacts?: IZKSnarkTrustedSetupArtifacts;
+  private baselineProxy?: Baseline;
+  private baselineCircuit?: Circuit;
+  private baselineMerkleTree?:any;
   private baselineConfig?: any;
   private babyJubJub?: VaultKey;
+  private domain?: string;
   private hdwallet?: VaultKey;
   private initialized = false;
   private nats?: IMessagingService;
@@ -43,7 +57,7 @@ export class ParticipantStack {
   private protocolSubscriptions: any[] = [];
   private capabilities?: Capabilities;
   private contracts: any;
-  private zk?: IZKSnarkCircuitProvider;
+  private privacy?: ICircuitRegistry & ICircuitProver & ICircuitVerifier;
 
   private org?: any;
   private workgroup?: any;
@@ -64,12 +78,20 @@ export class ParticipantStack {
 
     this.baseline = await baselineServiceFactory(baselineProviderProvide, this.baselineConfig);
     this.nats = await messagingServiceFactory(messagingProviderNats, this.natsConfig);
-    this.zk = await zkSnarkCircuitProviderServiceFactory(zkSnarkCircuitProviderServiceZokrates, {
-      importResolver: zokratesImportResolver,
-    });
+    this.privacy = await zkSnarkCircuitProviderServiceFactory(zkSnarkCircuitProviderServiceProvide, {
+      token: this.baselineConfig?.token,
+      privacyApiScheme: this.baselineConfig?.privacyApiScheme,
+      privacyApiHost: this.baselineConfig?.privacyApiHost,
+    }) as unknown as ICircuitRegistry & ICircuitProver & ICircuitVerifier; // HACK
 
     if (this.natsConfig?.natsBearerTokens) {
       this.natsBearerTokens = this.natsConfig.natsBearerTokens;
+    }
+
+    if (this.baselineConfig?.domain) {
+      this.domain = this.baselineConfig?.domain;
+    } else {
+      this.domain = baselineProtocolDefaultDomain;
     }
 
     this.contracts = {};
@@ -88,8 +110,8 @@ export class ParticipantStack {
     this.initialized = true;
   }
 
-  getBaselineCircuitArtifacts(): any | undefined {
-    return this.baselineCircuitArtifacts;
+  getBaselineCircuit(): Circuit | undefined {
+    return this.baselineCircuit;
   }
 
   getBaselineConfig(): any | undefined {
@@ -152,83 +174,13 @@ export class ParticipantStack {
     return this.workgroupCounterparties;
   }
 
+  async disconnect() {
+    await this.nats?.flush();
+    await this.nats?.disconnect();
+  }
+
   private async dispatchProtocolMessage(msg: ProtocolMessage): Promise<any> {
-    if (msg.opcode === Opcode.Baseline) {
-      const vault = await this.requireVault();
-      const workflowSignatories = 2;
-
-      const payload = JSON.parse(msg.payload.toString());
-      if (payload.doc) {
-        if (!payload.sibling_path) {
-          payload.sibling_path = [];
-        }
-        if (!payload.signatures) {
-          payload.signatures = [];
-        }
-        if (!payload.hash) {
-          payload.hash = sha256(JSON.stringify(payload.doc));
-        }
-
-        if (payload.signatures.length === 0) {
-          // baseline this new document
-          payload.result = await this.generateProof('preimage', JSON.parse(msg.payload.toString()));
-          const signature = (await this.signMessage(vault.id!, this.babyJubJub?.id!, payload.result.proof.proof)).signature;
-          payload.signatures = [signature];
-          this.workgroupCounterparties.forEach(async recipient => {
-            this.sendProtocolMessage(msg.sender, Opcode.Baseline, payload);
-          });
-        } else if (payload.signatures.length < workflowSignatories) {
-            if (payload.sibling_path && payload.sibling_path.length > 0) {
-              // perform off-chain verification to make sure this is a legal state transition
-              const root = payload.sibling_path[0];
-              const verified = this.baseline?.verify(this.contracts['shield'].address, payload.leaf, root, payload.sibling_path);
-              if (!verified) {
-                console.log('WARNING-- off-chain verification of proposed state transition failed...');
-                this.workgroupCounterparties.forEach(async recipient => {
-                  this.sendProtocolMessage(recipient, Opcode.Baseline, { err: 'verification failed' });
-                });
-                return Promise.reject('failed to verify');
-              }
-            }
-
-            // sign state transition
-            const signature = (await this.signMessage(vault.id!, this.babyJubJub?.id!, payload.hash)).signature;
-            payload.signatures.push(signature);
-            this.workgroupCounterparties.forEach(async recipient => {
-              this.sendProtocolMessage(recipient, Opcode.Baseline, payload);
-            });
-        } else {
-          // create state transition commitment
-          payload.result = await this.generateProof('modify_state', JSON.parse(msg.payload.toString()));
-          const publicInputs = []; // FIXME
-          const value = ''; // FIXME
-          console.log(payload);
-
-          const resp = await this.baseline?.verifyAndPush(
-            msg.sender,
-            this.contracts['shield'].address,
-            payload.result.proof.proof,
-            publicInputs,
-            value,
-          );
-
-          const leaf = resp!.commitment as MerkleTreeNode;
-
-          if (leaf) {
-            console.log(`inserted leaf... ${leaf}`);
-            payload.sibling_path = (await this.baseline!.getProof(msg.shield, leaf.location())).map(node => node.location());
-            payload.sibling_path?.push(leaf.index);
-            this.workgroupCounterparties.forEach(async recipient => {
-              await this.sendProtocolMessage(recipient, Opcode.Baseline, payload);
-            });
-        } else {
-            return Promise.reject('failed to insert leaf');
-          }
-        }
-      } else if (payload.signature) {
-        console.log(`NOOP!!! received signature in BLINE protocol message: ${payload.signature}`);
-      }
-    } else if (msg.opcode === Opcode.Join) {
+    if (msg.opcode === Opcode.Join) {
       const payload = JSON.parse(msg.payload.toString());
       const messagingEndpoint = await this.resolveMessagingEndpoint(payload.address);
       if (!messagingEndpoint || !payload.address || !payload.authorized_bearer_token) {
@@ -236,8 +188,43 @@ export class ParticipantStack {
       }
       this.workgroupCounterparties.push(payload.address);
       this.natsBearerTokens[messagingEndpoint] = payload.authorized_bearer_token;
+
+      const circuit = JSON.parse(JSON.stringify(this.baselineCircuit));
+      circuit.proving_scheme = circuit.provingScheme;
+      circuit.verifier_contract = circuit.verifierContract;
+      delete circuit.verifierContract;
+      delete circuit.createdAt; 
+      delete circuit.vaultId;
+      delete circuit.provingScheme;
+      delete circuit.provingKeyId;
+      delete circuit.verifyingKeyId;
+      delete circuit.status;
+
+      // sync circuit artifacts
+      this.sendProtocolMessage(payload.address, Opcode.Sync, {
+        type: 'circuit',
+        payload: circuit,
+      });
+    } else if (msg.opcode === Opcode.Sync) {
+      const payload = JSON.parse(msg.payload.toString());
+      if (payload.type === 'circuit') {
+        this.baselineCircuit = await this.privacy?.deploy(payload.payload) as Circuit;
+      }
     }
   }
+
+  async createBaselineObject(params: object): Promise<BaselineObject> {
+    return (await this.baselineProxy?.createObject(params)) as BaselineObject;
+  }
+
+  async updateBaselineObject(id: string, params: object): Promise<BaselineObject> {
+    return (await this.baselineProxy?.updateObject(id, params)) as BaselineObject;
+  }
+
+  async getMerkleRoot(): Promise<String> {
+    return (await this.baselineMerkleTree?.Root());
+  }
+
 
   // HACK!! workgroup/contracts should be synced via protocol
   async acceptWorkgroupInvite(inviteToken: string, contracts: any): Promise<void> {
@@ -306,7 +293,7 @@ export class ParticipantStack {
     this.natsBearerTokens[messagingEndpoint] = invite.prvd.data.params.authorized_bearer_token;
     this.workflowIdentifier = invite.prvd.data.params.workflow_identifier;
 
-    await this.baseline?.track(invite.prvd.data.params.shield_contract_address).catch((err) => {});
+    await this.baseline?.track(invite.prvd.data.params.shield_contract_address).catch((err) => { });
     await this.registerOrganization(this.baselineConfig.orgName, this.natsConfig.natsServers[0]);
     await this.requireOrganization(await this.resolveOrganizationAddress());
     await this.sendProtocolMessage(counterpartyAddr, Opcode.Join, {
@@ -314,86 +301,6 @@ export class ParticipantStack {
       authorized_bearer_token: await this.vendNatsAuthorization(),
       workflow_identifier: this.workflowIdentifier,
     });
-  }
-
-  private marshalCircuitArg(val: string, fieldBits?: number): string[] {
-    const el = elementify(val) as Element;
-    return el.field(fieldBits || 128, 1, true);
-  }
-
-  async generateProof(type: string, msg: any): Promise<any> {
-    const senderZkPublicKey = this.babyJubJub?.publicKey!;
-    let commitment: string;
-    let root: string | null = null;
-    const salt = msg.salt || rndHex(32);
-    if (msg.sibling_path && msg.sibling_path.length > 0) {
-      const siblingPath = elementify(msg.sibling_path) as Element;
-      root = siblingPath[0].hex(64);
-    }
-
-    console.log(`generating ${type} proof...\n`, msg);
-
-    switch (type) {
-      case 'preimage': // create agreement
-        const preimage = concatenateThenHash({
-          erc20ContractAddress: this.marshalCircuitArg(this.contracts['erc1820-registry'].address),
-          senderPublicKey: this.marshalCircuitArg(senderZkPublicKey),
-          name: this.marshalCircuitArg(msg.doc.name),
-          url: this.marshalCircuitArg(msg.doc.url),
-          hash: this.marshalCircuitArg(msg.hash),
-        });
-        console.log(`generating state genesis with preimage: ${preimage}; salt: ${salt}`);
-        commitment = concatenateThenHash(preimage, salt);
-        break;
-
-      case 'modify_state': // modify commitment state, nullify if applicable, etc.
-        const _commitment = concatenateThenHash({
-          senderPublicKey: this.marshalCircuitArg(senderZkPublicKey),
-          name: this.marshalCircuitArg(msg.doc.name),
-          url: this.marshalCircuitArg(msg.doc.url),
-          hash: this.marshalCircuitArg(msg.hash),
-        });
-        console.log(`generating state transition commitment with calculated delta: ${_commitment}; root: ${root}, salt: ${salt}`);
-        commitment = concatenateThenHash(root, _commitment, salt);
-        break;
-
-      default:
-        throw new Error('invalid proof type');
-    }
-
-    const args = [
-      this.marshalCircuitArg(commitment), // should == what we are computing in the circuit
-      {
-        value: [
-          this.marshalCircuitArg(commitment.substring(0, 16)),
-          this.marshalCircuitArg(commitment.substring(16)),
-        ],
-        salt: [
-          this.marshalCircuitArg(salt.substring(0, 16)),
-          this.marshalCircuitArg(salt.substring(16)),
-        ],
-      },
-      {
-        senderPublicKey: [
-          this.marshalCircuitArg(senderZkPublicKey.substring(0, 16)),
-          this.marshalCircuitArg(senderZkPublicKey.substring(16)),
-        ],
-        agreementName: this.marshalCircuitArg(msg.doc.name),
-        agreementUrl: this.marshalCircuitArg(msg.doc.url),
-      }
-    ];
-
-    const proof = await this.zk?.generateProof(
-      this.baselineCircuitArtifacts?.program,
-      (await this.zk?.computeWitness(this.baselineCircuitArtifacts!, args)).witness,
-      this.baselineCircuitSetupArtifacts?.keypair?.pk,
-    );
-
-    return {
-      doc: msg.doc,
-      proof: proof,
-      salt: salt,
-    };
   }
 
   async resolveMessagingEndpoint(addr: string): Promise<string> {
@@ -535,7 +442,7 @@ export class ParticipantStack {
       this.workgroupToken,
       this.baselineConfig?.identApiScheme,
       this.baselineConfig?.identApiHost,
-    ).fetchApplicationOrganizations(this.workgroup.id, {}));
+    ).fetchApplicationOrganizations(this.workgroup.id, {})).results;
   }
 
   async createOrgToken(): Promise<Token> {
@@ -545,6 +452,17 @@ export class ParticipantStack {
       this.baselineConfig?.identApiHost,
     ).createToken({
       organization_id: this.org.id,
+    });
+  }
+
+  async createOrgRefreshToken(): Promise<Token> {
+    return await Ident.clientFactory(
+      this.baselineConfig?.token,
+      this.baselineConfig?.identApiScheme,
+      this.baselineConfig?.identApiHost,
+    ).createToken({
+      organization_id: this.org.id,
+      scope: 'offline_access',
     });
   }
 
@@ -560,9 +478,17 @@ export class ParticipantStack {
 
   async resolveOrganizationAddress(): Promise<string> {
     const keys = await this.fetchKeys();
-    if (keys && keys.length >= 3) {
-      return keys[2].address; // HACK!
+    var address;
+    keys.forEach(key => {
+      if (key.spec == 'secp256k1') {
+        address = key.address; // HACK!
+      }
+    });
+
+    if (address) {
+      return Promise.resolve(address);
     }
+
     return Promise.reject('failed to resolve organization address');
   }
 
@@ -593,14 +519,74 @@ export class ParticipantStack {
     if (resp && resp['response'] && resp['response'][0] !== '0x0000000000000000000000000000000000000000') {
       const org = {} as Organization;
       org.name = resp['response'][1].toString();
+      // FIXME-- merge into metadata...
       org['address'] = resp['response'][0];
       org['config'] = JSON.parse(atob(resp['response'][5]));
-      org['config']['messaging_endpoint'] = atob(resp['response'][2]);
+      org['config']['domain'] = atob(resp['response'][2]);
+      org['config']['messaging_endpoint'] = atob(resp['response'][3]);
       org['config']['zk_public_key'] = atob(resp['response'][4]);
       return Promise.resolve(org);
     }
 
     return Promise.reject(`failed to fetch organization ${address}`);
+  }
+
+  async requireBaselineStack(token?: string): Promise<boolean> {
+    if (!token) {
+      const orgToken = await this.createOrgToken();
+      token = orgToken.accessToken || orgToken.token;
+    } 
+    return await tryTimes(async () => {
+      const status = await Baseline.fetchStatus(
+        this.baselineConfig.baselineApiScheme!,
+        this.baselineConfig.baselineApiHost!,
+      );
+      if (status != null) {
+        return true;
+      }
+      throw new Error();
+    }, 100, 5000);
+  }
+
+  async requireIdent(token?: string): Promise<boolean> {
+    if (!token) {
+      const orgToken = await this.createOrgToken();
+      token = orgToken.accessToken || orgToken.token;
+    } 
+
+    return await tryTimes(async () => {
+      const status = await Ident.fetchStatus(
+        this.baselineConfig.identApiScheme!,
+        this.baselineConfig.identApiHost!,
+      );
+      if (status != null) {
+        return true;
+      }
+      throw new Error();
+    }, 100, 5000);
+  }
+
+  async requireCircuit(circuitId: string): Promise<Circuit> {
+    let circuit: Circuit | undefined = undefined;
+    const orgToken = await this.createOrgToken();
+    const tkn = orgToken.accessToken || orgToken.token;
+
+    let interval;
+    const promises = [] as any;
+    promises.push(new Promise<void>((resolve, reject) => {
+      interval = setInterval(async () => {
+        circuit = await this.privacy?.fetchCircuit(circuitId) as Circuit;
+        if (circuit && circuit.verifierContract && circuit.verifierContract['source']) {
+          resolve();
+        }
+      }, 2500);
+    }));
+
+    await Promise.all(promises);
+    clearInterval(interval);
+    interval = null;
+
+    return circuit!;
   }
 
   async fetchVaults(): Promise<ProvideVault[]> {
@@ -610,7 +596,7 @@ export class ParticipantStack {
       token!,
       this.baselineConfig.vaultApiScheme!,
       this.baselineConfig.vaultApiHost!,
-    ).fetchVaults({}));
+    ).fetchVaults({})).results;
   }
 
   async createVaultKey(vaultId: string, spec: string, type?: string, usage?: string): Promise<VaultKey> {
@@ -631,34 +617,23 @@ export class ParticipantStack {
   }
 
   async requireVault(token?: string): Promise<ProvideVault> {
-    let vault;
     let tkn = token;
     if (!tkn) {
       const orgToken = await this.createOrgToken();
       tkn = orgToken.accessToken || orgToken.token;
     }
 
-    let interval;
-    const promises = [] as any;
-    promises.push(new Promise((resolve, reject) => {
-      interval = setInterval(async () => {
-        const vaults = await Vault.clientFactory(
-          tkn!,
-          this.baselineConfig.vaultApiScheme!,
-          this.baselineConfig.vaultApiHost!,
-        ).fetchVaults({});
-        if (vaults && vaults.length > 0) {
-          vault = vaults[0];
-          resolve();
-        }
-      }, 2500);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
-
-    return vault;
+    return await tryTimes(async () => {
+      const vaults = await Vault.clientFactory(
+        tkn!,
+        this.baselineConfig.vaultApiScheme!,
+        this.baselineConfig.vaultApiHost!,
+      ).fetchVaults({});
+      if (vaults && vaults.results.length > 0) {
+        return vaults.results[0];
+      }
+      throw new Error();
+    });
   }
 
   async signMessage(vaultId: string, keyId: string, message: string): Promise<any> {
@@ -668,42 +643,51 @@ export class ParticipantStack {
     return (await vault.signMessage(vaultId, keyId, message));
   }
 
-  async fetchKeys(): Promise<any> {
+  async fetchKeys(): Promise<VaultKey[]> {
     const orgToken = await this.createOrgToken();
     const token = orgToken.accessToken || orgToken.token;
     const vault = Vault.clientFactory(token!, this.baselineConfig?.vaultApiScheme, this.baselineConfig?.vaultApiHost);
     const vlt = await this.requireVault(token!);
-    return (await vault.fetchVaultKeys(vlt.id!, {}));
+    return (await vault.fetchVaultKeys(vlt.id!, {})).results;
   }
 
-  async compileBaselineCircuit(): Promise<any> {
-    const src = readFileSync(baselineDocumentCircuitPath).toString();
-    this.baselineCircuitArtifacts = await this.zk?.compile(src, 'main');
-    return this.baselineCircuitArtifacts;
+  async fetchSecret(vaultId: string, secretId: string): Promise<any> {
+    const orgToken = await this.createOrgToken();
+    const token = orgToken.accessToken || orgToken.token;
+    const vault = Vault.clientFactory(token!, this.baselineConfig?.vaultApiScheme, this.baselineConfig?.vaultApiHost);
+    return (await vault.fetchVaultSecret(vaultId, secretId));
   }
 
-  async deployBaselineCircuit(): Promise<any> {
-    // compile the circuit...
-    await this.compileBaselineCircuit();
-
+  async deployBaselineCircuit(): Promise<Circuit> {
     // perform trusted setup and deploy verifier/shield contract
-    const setupArtifacts = await this.zk?.setup(this.baselineCircuitArtifacts);
-    const compilerOutput = JSON.parse(solidityCompile(JSON.stringify({
-      language: 'Solidity',
-      sources: {
-        'verifier.sol': {
-          content: setupArtifacts?.verifierSource?.replace(/\^0.6.1/g, '^0.7.3').replace(/view/g, ''),
-        },
-      },
-      settings: {
-        outputSelection: {
+    const circuit = await this.privacy?.deploy({
+      identifier: 'purchase_order',
+      proving_scheme: 'groth16',
+      curve: 'BN254',
+      provider: 'gnark',
+      name: 'my 1337 circuit',
+    }) as Circuit;
+
+    this.baselineCircuit = await this.requireCircuit(circuit.id!);
+    this.workflowIdentifier = this.baselineCircuit?.id;
+    const content = this.baselineCircuit?.verifierContract!['source'].replace(/\^0.5.0/g, '^0.7.3').replace(/view/g, '').replace(/gas,/g, 'gas(),').replace(/\\n/g, /\n/).replace(/uint256\[0\]/g, 'uint256[]')
+    const input = {
+      'language': 'Solidity',
+      'settings': {
+        'outputSelection': {
           '*': {
-            '*': ['*'],
-          },
+            '*': ['*']
+          }
         }
       },
-    })));
+      'sources': {
+        'verifier.sol': {
+          'content': content
+        }
+      }
+    };
 
+    const compilerOutput = JSON.parse(solidityCompile(JSON.stringify(input)));
     if (!compilerOutput.contracts || !compilerOutput.contracts['verifier.sol']) {
       throw new Error('verifier contract compilation failed');
     }
@@ -711,17 +695,9 @@ export class ParticipantStack {
     const contractParams = compilerOutput.contracts['verifier.sol']['Verifier'];
     await this.deployWorkgroupContract('Verifier', 'verifier', contractParams);
     await this.requireWorkgroupContract('verifier');
+    await this.deployWorkgroupShieldContract();
 
-    const shieldAddress = await this.deployWorkgroupShieldContract();
-    const trackedShield = await this.baseline?.track(shieldAddress);
-    if (!trackedShield) {
-      console.log('WARNING: failed to track baseline shield contract');
-    }
-
-    this.baselineCircuitSetupArtifacts = setupArtifacts;
-    this.workflowIdentifier = this.baselineCircuitSetupArtifacts?.identifier;
-
-    return setupArtifacts;
+    return this.baselineCircuit;
   }
 
   async deployWorkgroupContract(name: string, type: string, params: any, arvg?: any[]): Promise<any> {
@@ -748,7 +724,6 @@ export class ParticipantStack {
       params: {
         account_id: signerResp['id'],
         compiled_artifact: params,
-        // network: 'kovan',
         argv: arvg || [],
       },
       name: name,
@@ -767,11 +742,9 @@ export class ParticipantStack {
   async deployWorkgroupShieldContract(): Promise<any> {
     const verifierContract = await this.requireWorkgroupContract('verifier');
     const registryContracts = JSON.parse(JSON.stringify(this.capabilities?.getBaselineRegistryContracts()));
-    const contractParams = registryContracts[3]; // "shuttle circle" factory contract
+    const contractParams = registryContracts[3]; // "shuttle circuit" factory contract
 
     const argv = ['MerkleTreeSHA Shield', verifierContract.address, 32];
-
-    console.log(contractParams);
 
     // deploy EYBlockchain's MerkleTreeSHA contract (see https://github.com/EYBlockchain/timber)
     await this.deployWorkgroupContract('ShuttleCircuit', 'circuit', contractParams, argv);
@@ -802,79 +775,36 @@ export class ParticipantStack {
   }
 
   private async requireCapabilities(): Promise<void> {
-    let interval;
-    const promises = [] as any;
-    promises.push(new Promise((resolve, reject) => {
-      interval = setInterval(async () => {
-        if (this.capabilities?.getBaselineRegistryContracts()) {
-          resolve();
-        }
-      }, 2500);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
+    return await tryTimes(async () => {
+      if (this.capabilities?.getBaselineRegistryContracts()) {
+        return;
+      }
+      throw new Error();
+    })
   }
 
   async requireOrganization(address: string): Promise<Organization> {
-    let organization;
-    let interval;
+    return await tryTimes(async () => {
+      const org = await this.fetchOrganization(address);
+      if (org && org['address'].toLowerCase() === address.toLowerCase()) {
+        return org;
+      }
 
-    const promises = [] as any;
-    promises.push(new Promise((resolve, reject) => {
-      interval = setInterval(async () => {
-        this.fetchOrganization(address).then((org) => {
-          if (org && org['address'].toLowerCase() === address.toLowerCase()) {
-            organization = org;
-            resolve();
-          }
-        }).catch((err) => { });
-      }, 5000);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
-
-    return organization;
+      throw new Error();
+    })
   }
 
   async requireWorkgroup(): Promise<void> {
-    let interval;
-    const promises = [] as any;
-    promises.push(new Promise((resolve, reject) => {
-      interval = setInterval(async () => {
-        if (this.workgroup) {
-          resolve();
-        }
-      }, 2500);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
+    return await tryTimes(async () => {
+      if (this.workgroup) {
+        return this.workgroup;
+      }
+      throw new Error();
+    })
   }
 
   async requireWorkgroupContract(type: string): Promise<any> {
-    let contract;
-    let interval;
-
-    const promises = [] as any;
-    promises.push(new Promise((resolve, reject) => {
-      interval = setInterval(async () => {
-        this.resolveWorkgroupContract(type).then((cntrct) => {
-          contract = cntrct;
-          resolve();
-        }).catch((err) => { });
-      }, 5000);
-    }));
-
-    await Promise.all(promises);
-    clearInterval(interval);
-    interval = null;
-
-    return contract;
+    return await tryTimes(() => this.resolveWorkgroupContract(type))
   }
 
   async resolveWorkgroupContract(type: string): Promise<any> {
@@ -888,8 +818,8 @@ export class ParticipantStack {
       type: type,
     });
 
-    if (contracts && contracts.length === 1 && contracts[0]['address'] !== '0x') {
-      const contract = await nchain.fetchContractDetails(contracts[0].id!);
+    if (contracts && contracts.results.length === 1 && contracts.results[0]['address'] !== '0x') {
+      const contract = await nchain.fetchContractDetails(contracts.results[0].id!);
       this.contracts[type] = contract;
       return Promise.resolve(contract);
     }
@@ -900,6 +830,7 @@ export class ParticipantStack {
     this.org = await this.baseline?.createOrganization({
       name: name,
       metadata: {
+        domain: this.domain,
         messaging_endpoint: messagingEndpoint,
       },
     });
@@ -909,10 +840,71 @@ export class ParticipantStack {
       this.babyJubJub = await this.createVaultKey(vault.id!, 'babyJubJub');
       await this.createVaultKey(vault.id!, 'secp256k1');
       this.hdwallet = await this.createVaultKey(vault.id!, 'BIP39');
+      await this.createVaultKey(vault.id!, 'RSA-4096');
       await this.registerWorkgroupOrganization();
+      await this.requireIdent();
+      await this.deployBaselineStack();
+      await this.requireBaselineStack();
     }
 
     return this.org;
+  }
+
+  async deployBaselineStack(): Promise<any> {
+    const orgToken = await this.createOrgToken();
+    const tkn = orgToken.accessToken || orgToken.token;
+
+    const orgRefreshToken = await this.createOrgRefreshToken();
+    const registryContract = await this.requireWorkgroupContract('organization-registry');
+
+    this.baselineProxy = baselineClientFactory(
+      tkn!,
+      this.baselineConfig?.baselineApiScheme,
+      this.baselineConfig?.baselineApiHost
+    );
+    const orgAddress= await this.resolveOrganizationAddress()
+
+    // Generate config file
+    const tokenResp = await this.createWorkgroupToken();
+    const configurationFileContents = `access-token: ${this.baselineConfig?.userAccessToken}\nrefresh-token: ${this.baselineConfig?.userRefreshToken}\n${this.workgroup.id}:\n  api-token: ${tokenResp.token}\n`;
+    const provideConfigFileName=`${process.cwd()}/.prvd-${this.baselineConfig?.orgName.replace(/\s+/g, '')}-cli.yaml`;
+    fs.writeFileSync(provideConfigFileName, configurationFileContents);
+    await this.requireIdent();
+    var name = this.baselineConfig?.orgName.split(' ')
+    const runenv = `LOG_LEVEL=TRACE IDENT_API_HOST=${this.baselineConfig?.identApiHost} IDENT_API_SCHEME=${this.baselineConfig?.identApiScheme} NCHAIN_API_HOST=${this.baselineConfig?.nchainApiHost} NCHAIN_API_SCHEME=${this.baselineConfig?.nchainApiScheme} VAULT_API_HOST=${this.baselineConfig?.vaultApiHost} VAULT_API_SCHEME=${this.baselineConfig?.vaultApiScheme} PROVIDE_ORGANIZATION_REFRESH_TOKEN=${orgRefreshToken.refreshToken}`
+    var runcmd = ` prvd baseline stack start`
+    runcmd += ` --api-endpoint="${this.baselineConfig?.baselineApiScheme}://${this.baselineConfig?.baselineApiHost}"`
+    runcmd += ` --config="${provideConfigFileName}"`
+    runcmd += ` --ident-host="${this.baselineConfig?.identApiHost}"`
+		runcmd += ` --ident-scheme="${this.baselineConfig?.identApiScheme}"`
+    runcmd += ` --messaging-endpoint="nats://localhost:${this.baselineConfig?.baselineMessagingPort}"`
+    runcmd += ` --name="${this.baselineConfig?.orgName.replace(/\s+/g, '')}"`
+    runcmd += ` --nats-auth-token="${this.natsConfig?.bearerToken}"`
+    runcmd += ` --nats-port=${this.baselineConfig?.baselineMessagingPort}`
+    runcmd += ` --nats-streaming-port=${this.baselineConfig?.baselineMessagingStreamingPort}`
+    runcmd += ` --nats-ws-port=${this.baselineConfig?.baselineMessagingWebsocketPort}`
+    runcmd += ` --nchain-host="${this.baselineConfig?.nchainApiHost}"`
+		runcmd += ` --nchain-scheme="${this.baselineConfig?.nchainApiScheme}"`
+		runcmd += ` --nchain-network-id="${this.baselineConfig?.networkId}"`
+		runcmd += ` --organization="${this.org.id}"`,
+    runcmd += ` --organization-address="${orgAddress}"`
+    runcmd += ` --organization-refresh-token="${orgRefreshToken.refreshToken}"`
+    runcmd += ` --port="${this.baselineConfig?.baselineApiHost.split(':')[1]}"`
+    runcmd += ` --privacy-host="${this.baselineConfig?.privacyApiHost}"`
+		runcmd += ` --privacy-scheme="${this.baselineConfig?.privacyApiScheme}"`
+		runcmd += ` --registry-contract-address="${registryContract.address}"`
+    runcmd += ` --redis-hostname=${name[0]}-redis`
+    runcmd += ` --redis-port=${this.baselineConfig?.redisPort}`
+    runcmd += ` --sor="ephemeral"`
+    runcmd += ` --vault-host="${this.baselineConfig?.vaultApiHost}"`
+		runcmd += ` --vault-refresh-token="${orgRefreshToken.refreshToken}"`
+		runcmd += ` --vault-scheme="${this.baselineConfig?.vaultApiScheme}"`
+		runcmd += ` --workgroup="${this.workgroup?.id}"`
+    
+    runcmd = runcmd.replace(/localhost/ig, 'host.docker.internal')
+
+    var child = spawn(runenv+runcmd, [], { detached: true, stdio: 'pipe', shell: true });
+    child.unref()
   }
 
   async startProtocolSubscriptions(): Promise<any> {
@@ -968,7 +960,7 @@ export class ParticipantStack {
         allow: ['baseline.>'],
       },
       subscribe: {
-        allow: [`baseline.inbound`],
+        allow: [`baseline.proxy`],
       },
     };
 
@@ -979,3 +971,5 @@ export class ParticipantStack {
     );
   }
 }
+
+

--- a/examples/bri-1/base-example/test/e2e.spec.ts
+++ b/examples/bri-1/base-example/test/e2e.spec.ts
@@ -1,11 +1,12 @@
 import { Opcode } from '@baseline-protocol/types';
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { ParticipantStack } from '../src';
 import {
   shouldBehaveLikeAWorkgroupOrganization,
   shouldBehaveLikeAnInitialWorkgroupOrganization,
   shouldBehaveLikeAnInvitedWorkgroupOrganization,
   shouldBehaveLikeAWorkgroupCounterpartyOrganization,
+  shouldCreateBaselineStack,
 } from './shared';
 
 import {
@@ -16,24 +17,28 @@ import {
   promisedTimeout,
   scrapeInvitationToken
 } from './utils';
+import { uuid } from 'uuidv4';
 
 const aliceCorpName = 'Alice Corp';
+const aliceDomain = 'alice.baseline.local';
+
 const bobCorpName = 'Bob Corp';
+const bobDomain = 'bob.baseline.local';
 
 const ropstenNetworkId = '66d44f30-9092-4182-a3c4-bc02736d6ae5';
 const kovanNetworkId = '8d31bf48-df6b-4a71-9d7c-3cb291111e27';
 const goerliNetworkId = '1b16996e-3595-4985-816c-043345d22f8c';
-const networkId = process.env['NCHAIN_NETWORK_ID'] || ropstenNetworkId;
+const networkId = process.env['NCHAIN_NETWORK_ID'] || kovanNetworkId;
 
 const setupUser = async (identHost, firstname, lastname, email, password) => {
   const user = (await createUser(identHost, firstname, lastname, email, password));
   const auth = await authenticateUser(identHost, email, password);
-  const bearerToken = auth.token.token;
-  assert(bearerToken, `failed to authorize bearer token for user ${email}`);
-  return [user, bearerToken];
+  const token = JSON.parse(JSON.stringify(auth.token));
+  assert(token.access_token, `failed to authorize bearer token for user ${email}`);
+  return [user, token.access_token, token.refresh_token];
 };
 
-describe('baseline', () => {
+describe('Baseline', () => {
   let bearerTokens; // user API credentials
 
   let alice;
@@ -76,8 +81,10 @@ describe('baseline', () => {
     const natsPublicKey = '-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAullT/WoZnxecxKwQFlwE\n9lpQrekSD+txCgtb9T3JvvX/YkZTYkerf0rssQtrwkBlDQtm2cB5mHlRt4lRDKQy\nEA2qNJGM1Yu379abVObQ9ZXI2q7jTBZzL/Yl9AgUKlDIAXYFVfJ8XWVTi0l32Vsx\ntJSd97hiRXO+RqQu5UEr3jJ5tL73iNLp5BitRBwa4KbDCbicWKfSH5hK5DM75EyM\nR/SzR3oCLPFNLs+fyc7zH98S1atglbelkZsMk/mSIKJJl1fZFVCUxA+8CaPiKbpD\nQLpzydqyrk/y275aSU/tFHidoewvtWorNyFWRnefoWOsJFlfq1crgMu2YHTMBVtU\nSJ+4MS5D9fuk0queOqsVUgT7BVRSFHgDH7IpBZ8s9WRrpE6XOE+feTUyyWMjkVgn\ngLm5RSbHpB8Wt/Wssy3VMPV3T5uojPvX+ITmf1utz0y41gU+iZ/YFKeNN8WysLxX\nAP3Bbgo+zNLfpcrH1Y27WGBWPtHtzqiafhdfX6LQ3/zXXlNuruagjUohXaMltH+S\nK8zK4j7n+BYl+7y1dzOQw4CadsDi5whgNcg2QUxuTlW+TQ5VBvdUl9wpTSygD88H\nxH2b0OBcVjYsgRnQ9OZpQ+kIPaFhaWChnfEArCmhrOEgOnhfkr6YGDHFenfT3/RA\nPUl1cxrvY7BHh4obNa6Bf8ECAwEAAQ==\n-----END PUBLIC KEY-----';
 
     aliceApp = await baselineAppFactory(
+      aliceUserToken[1],
+      aliceUserToken[2],
       aliceCorpName,
-      bearerTokens[alice['id']],
+      aliceDomain,
       false,
       'localhost:8081',
       'nats://localhost:4222',
@@ -86,8 +93,15 @@ describe('baseline', () => {
       'localhost:8080',
       networkId,
       'localhost:8082',
-      'nethermind-ropsten.provide.services:8888',
-      'http',
+      'localhost:8084',
+      'localhost:8092',
+      '4722',
+      '4320',
+      '4321',
+      'kovan.poa.network:443',
+      'https',
+      'localhost',
+      '6390',
       null,
       'baseline workgroup',
       null,
@@ -95,8 +109,10 @@ describe('baseline', () => {
     );
 
     bobApp = await baselineAppFactory(
+      bobUserToken[1],
+      bobUserToken[2],
       bobCorpName,
-      bearerTokens[bob['id']],
+      bobDomain,
       true,
       'localhost:8085',
       'nats://localhost:4224',
@@ -105,18 +121,30 @@ describe('baseline', () => {
       'localhost:8086',
       networkId,
       'localhost:8083',
-      'nethermind-ropsten.provide.services:8888',
-      'http',
+      'localhost:8087',
+      'localhost:8089',
+      '4724',
+      '4322',
+      '4323',
+      'kovan.poa.network:443',
+      'https',
+      'localhost',
+      '6391',
       null,
       'baseline workgroup',
       null,
       'forest step weird object extend boat ball unit canoe pull render monkey drink monitor behind supply brush frown alone rural minute level host clock',
     );
 
-    bobApp.init();
-    aliceApp.init();
+    await bobApp.init();
+    await aliceApp.init();
   });
 
+  after('close connections',async () =>{
+    await bobApp.disconnect();
+    await aliceApp.disconnect();
+  })
+  
   describe('workgroup', () => {
     describe('creation', () => {
       before(async () => {
@@ -135,14 +163,14 @@ describe('baseline', () => {
         assert(workgroupToken, 'workgroup token should not be null');
       });
 
-      it('should deploy the ERC1820 registry contract for the workgroup', async () => {
+      it('should deploy the global ERC1820 registry contract', async () => {
         const erc1820RegistryContract = await bobApp.requireWorkgroupContract('erc1820-registry');
-        assert(erc1820RegistryContract, 'workgroup ERC1820 registry contract should not be null');
+        assert(erc1820RegistryContract, 'global ERC1820 registry contract should not be null');
       });
 
-      it('should deploy the ERC1820 organization registry contract for the workgroup', async () => {
+      it('should deploy the global ERC1820 organization registry contract', async () => {
         const orgRegistryContract = await bobApp.requireWorkgroupContract('organization-registry');
-        assert(orgRegistryContract, 'workgroup organization registry contract should not be null');
+        assert(orgRegistryContract, 'global organization registry contract should not be null');
       });
     });
 
@@ -157,20 +185,16 @@ describe('baseline', () => {
         assert(workgroupToken, 'workgroup token should not be null');
       });
 
-      describe('workgroup initiator', function () {
-        before(async () => {
-          this.ctx.app = bobApp;
-        });
-
-        describe(`initial workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAnInitialWorkgroupOrganization.bind(this));
-        describe(`workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAWorkgroupOrganization.bind(this));
+      describe('workgroup initiator', () => {
+        describe(`baseline stack for "${bobCorpName}"`, shouldCreateBaselineStack(() => bobApp))
+        describe(`initial workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAnInitialWorkgroupOrganization(() => bobApp));
+        describe(`workgroup organization: "${bobCorpName}"`, shouldBehaveLikeAWorkgroupOrganization(() => bobApp));
       });
 
       describe('inviting participants to the workgroup', function () {
         let inviteToken;
 
         before(async () => {
-          this.ctx.app = aliceApp;
           await bobApp.inviteWorkgroupParticipant(alice.email);
           inviteToken = await scrapeInvitationToken('bob-ident-consumer'); // if configured, ident would have sent an email to Alice
         });
@@ -186,41 +210,79 @@ describe('baseline', () => {
             await aliceApp.acceptWorkgroupInvite(inviteToken, bobApp.getWorkgroupContracts());
           });
 
-          describe(`invited workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAnInvitedWorkgroupOrganization.bind(this));
-          describe(`workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupOrganization.bind(this));
-          describe(`workgroup counterparty: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupCounterpartyOrganization.bind(this));
+          describe(`baseline stack for "${aliceCorpName}"`, shouldCreateBaselineStack(() => aliceApp))
+          describe(`invited workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAnInvitedWorkgroupOrganization(() => aliceApp));
+          describe(`workgroup organization: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupOrganization(() => aliceApp));
+          describe(`workgroup counterparty: "${aliceCorpName}"`, shouldBehaveLikeAWorkgroupCounterpartyOrganization(() => aliceApp));
         });
 
         describe('counterparties post-onboarding', function () {
-          before(async () => {
-            this.ctx.app = bobApp;
-          });
-
-          describe(bobCorpName, shouldBehaveLikeAWorkgroupCounterpartyOrganization.bind(this));
+          describe(bobCorpName, shouldBehaveLikeAWorkgroupCounterpartyOrganization(() => bobApp));
         });
       });
 
       describe('workflow', () => {
-        describe('workstep', () => {
+        var workstepId
+
+        describe('create a work step', () => {
           before(async () => {
+            await bobApp.requireBaselineStack();
+
+            workstepId = String(uuid())
             const recipient = await aliceApp.resolveOrganizationAddress();
-            await bobApp.sendProtocolMessage(recipient, Opcode.Baseline, {
-              id: 'uuidv4()',
-              name: 'hello world',
-              url: 'proto://deep/link/to/doc',
-              rfp_id: null,
+
+            await bobApp.createBaselineObject({
+              "id": workstepId,
+              "payload": {
+                "proof": "8d8f7498db7aee910428c737d8427ac4add98353f981ca70db07697a091d8c23972b55b0b20fc0eebc1ac6c2ae427d783291c7fcb2e3f7417d279fea78ce1eac2d2293e53579abbef4960a1e290bd023e2999d8ff423d01080d449ce5d14ca89c94e277e8e0bb14fb91a0b71129920ae4411e77685287611f4d2aaf66b8fc5dc",
+                "type": "general_consistency",
+                "witness":{}
+              },
+              "type":"general_consistency",
             });
-          });
+        })
 
           it('should increment protocol message tx count for the sender', async () => {
-            assert(bobApp.getProtocolMessagesTx() === 1, 'protocol messages tx should equal 1');
+            assert(bobApp.getProtocolMessagesTx() === 1, 'protocol messages tx should equal 2');
           });
 
           it('should increment protocol message rx count for the recipient', async () => {
             await promisedTimeout(50);
-            assert(aliceApp.getProtocolMessagesRx() === 1, 'protocol messages rx should equal 1');
+            assert(aliceApp.getProtocolMessagesRx() === 1, 'protocol messages rx should equal 2');
           });
+
+          // it('should match the merkle root between sender and receiver', async() => {
+          //   let bobRoot = bobApp.getMerkleRoot()
+          //   let aliceRoot = aliceApp.getMerkleRoot()
+          //   expect(bobRoot).to.equal(aliceRoot);
+          // })
         });
+
+        // describe('update a work step', () => {
+        //   before(async () => {
+        //     await aliceApp.updateBaselineObject(workstepId,{
+        //       id: 'uuidv4()',
+        //       name: 'hello world',
+        //       url: 'proto://deep/link/to/doc',
+        //       rfp_id: uuid(),
+        //     });
+        //   });
+
+        //   it('should increment protocol message tx count for the sender', async () => {
+        //     assert(aliceApp.getProtocolMessagesTx() === 2, 'protocol messages tx should equal 2');
+        //   });
+
+        //   it('should increment protocol message rx count for the recipient', async () => {
+        //     await promisedTimeout(50);
+        //     assert(bobApp.getProtocolMessagesRx() === 2, 'protocol messages rx should equal 2');
+        //   });
+
+        //   it('should match the merkle root between sender and receiver', async() => {
+        //     let bobRoot = bobApp.getMerkleRoot()
+        //     let aliceRoot = aliceApp.getMerkleRoot()
+        //     expect(bobRoot).to.equal(aliceRoot);
+        //   })
+        // });
       });
     });
   });

--- a/examples/bri-1/base-example/test/utils.ts
+++ b/examples/bri-1/base-example/test/utils.ts
@@ -1,6 +1,7 @@
 import { exec } from 'child_process';
 import * as log from 'loglevel';
 import { Client } from 'pg';
+import { domain } from 'process';
 import { Ident } from 'provide-js';
 import { AuthService } from 'ts-natsutil';
 import { ParticipantStack } from '../src/index';
@@ -9,17 +10,50 @@ export const promisedTimeout = (ms) => {
   return new Promise(resolve => setTimeout(resolve, ms));
 };
 
+const infuraProjectId = '';
+const altNetworkConfiguration = JSON.stringify({
+  "chainspec_url": "https://",
+  "chain": "kovan",
+  "client": "geth",
+  "engine_id": "ethash",
+  "is_ethereum_network": true,
+  "json_rpc_url": `https://kovan.infura.io/v3/${infuraProjectId}`,
+  "native_currency": "ETH",
+  "network_id": 42,
+  "platform": "evm",
+  "protocol_id": "pow",
+  "websocket_url": `wss://kovan.infura.io/ws/v3/${infuraProjectId}`,
+  "security": {
+      "egress": "*",
+      "ingress": {
+          "0.0.0.0/0": {
+              "tcp": [
+                  8050,
+                  8051,
+                  30300
+              ],
+              "udp": [
+                  30300
+              ]
+          }
+      }
+  }
+})
+
 export const authenticateUser = async (identHost, email, password) => {
   const auth = await Ident.authenticate({
     email: email,
     password: password,
+    scope: 'offline_access',
   }, 'http', identHost);
   return auth;
 };
 
 export const baselineAppFactory = async (
+  userAccessToken,
+  userRefreshToken,
   orgName,
-  bearerToken,
+  domain,
   initiator,
   identHost,
   natsHost,
@@ -28,8 +62,15 @@ export const baselineAppFactory = async (
   nchainHost,
   networkId,
   vaultHost,
-  rcpEndpoint,
+  privacyHost,
+  baselineHost,
+  baselineMessagingPort,
+  baselineMessagingStreamingPort,
+  baselineMessagingWebsocketPort,
+  rpcEndpoint,
   rpcScheme,
+  redisHost,
+  redisPort,
   workgroup,
   workgroupName,
   workgroupToken,
@@ -41,20 +82,32 @@ export const baselineAppFactory = async (
     privateKey: natsPrivateKey,
     publicKey: natsPublicKey,
   };
-  natsConfig.bearerToken = await vendNatsAuthorization(natsConfig, 'baseline.inbound');
+  natsConfig.bearerToken = await vendNatsAuthorization(natsConfig, 'baseline.proxy');
 
   return new ParticipantStack(
     {
+      baselineApiScheme: 'http',
+      baselineApiHost: baselineHost,
+      baselineMessagingPort: baselineMessagingPort,
+      baselineMessagingStreamingPort: baselineMessagingStreamingPort,
+      baselineMessagingWebsocketPort: baselineMessagingWebsocketPort,
+      domain: domain,
       identApiScheme: 'http',
       identApiHost: identHost,
       initiator: initiator,
       nchainApiScheme: 'http',
       nchainApiHost: nchainHost,
+      privacyApiScheme: 'http',
+      privacyApiHost: privacyHost,
       networkId: networkId, // FIXME-- boostrap network genesis if no public testnet faucet is configured...
       orgName: orgName,
-      rpcEndpoint: rcpEndpoint,
+      rpcEndpoint: rpcEndpoint,
       rpcScheme: rpcScheme,
-      token: bearerToken,
+      redisHost: redisHost,
+      redisPort: redisPort,
+      token: userAccessToken, // HACK
+      userAccessToken: userAccessToken,
+      userRefreshToken: userRefreshToken,
       vaultApiScheme: 'http',
       vaultApiHost: vaultHost,
       vaultSealUnsealKey: vaultSealUnsealKey,
@@ -78,6 +131,7 @@ export const configureTestnet = async (dbport, networkId) => {
   try {
     await nchainPgclient.connect();
     await nchainPgclient.query(`UPDATE networks SET enabled = true WHERE id = '${networkId}'`);
+    await nchainPgclient.query(`UPDATE networks SET config = '${altNetworkConfiguration}' WHERE id = '${networkId}'`);
   } finally {
     await nchainPgclient.end();
     return true;
@@ -95,11 +149,14 @@ export const createUser = async (identHost, firstName, lastName, email, password
 };
 
 export const scrapeInvitationToken = async (container) => {
+  await promisedTimeout(800);
+
   let logs;
   exec(`docker logs ${container}`, (err, stdout, stderr) => {
    logs = stderr.toString();
   });
-  await promisedTimeout(500);
+
+  await promisedTimeout(800);
   const matches = logs.match(/\"dispatch invitation\: (.*)\"/);
   if (matches && matches.length > 0) {
     return matches[matches.length - 1];
@@ -120,7 +177,7 @@ export const vendNatsAuthorization = async (natsConfig, subject): Promise<string
       allow: ['baseline.>'],
     },
     subscribe: {
-      allow: [`baseline.inbound`],
+      allow: [`baseline.proxy`],
     },
   };
 


### PR DESCRIPTION
# Description
This reference implementation of the core interfaces specified in the v1.0 release of the Baseline Protocol is called BRI-1 and has been contributed to the open source community under a public domain CCO-Universal license by individuals and companies including Provide, EY, Nethermind, ConsenSys, and others. It heavily utilizes the core Provide application stack and is compatible with Shuttle, an on-ramp for baselining.
The reference implementation is instrumented to run on the Ethereum Ropsten testnet and can be configured to run on many other public or permissioned EVM-based blockchain.

## How Has This Been Tested

This PR  has  been end to end tested following Alice & Bob, respective owners of Alice Corp and Bob Corp, establishing a workgroup and baselining an in-memory record (i.e., a JSON object) using the Provide stack.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
