### PR TITLE
Update Codeowners - fix typo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @skarred14 @kthomas @ognjenkurtic @rfisch @therecanonlybeone1969 @fosgate29 @Manik-Jain @skosito @Kasshern
+*       @skarred14 @kthomas @ognjenkurtic @rfisch @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern


### PR DESCRIPTION
Made fix to @Therecanbeonlyone1969 's GH ID.

# Description

Maintainer, Andreas Freund's, GH ID is incorrect in the codeowners file. 
