### PR TITLE
Add branch-naming.md with the standard for naming to docs

### DIFF
--- a/docs/baseline-protocol-code/branch-naming.md
+++ b/docs/baseline-protocol-code/branch-naming.md
@@ -10,6 +10,9 @@
 
 *feature/BLIP-#-repo-branch-standards* - related BLIP-#.
 
+Note: *When working on a branch that covers multiple issues and\or bugs, use the main one for the name of the branch but make sure
+to link all of the affected issues before merging the PR.*
+
 ## Bugs
 
 *bugfix/XYZ-name-of-the-bug* - related issue with number id XYZ.

--- a/docs/baseline-protocol-code/branch-naming.md
+++ b/docs/baseline-protocol-code/branch-naming.md
@@ -1,0 +1,23 @@
+# Branch Naming Standard
+
+## Main
+
+*main* - main development branch, feature and release branches branched from it, changes only through the PR process.
+
+## Feature
+
+*feature/XYZ-this-is-a-new-feature-branch* - in case related issue XYZ exists
+
+*feature/BLIP-#-repo-branch-standards* - in case related BLIP-# exists
+
+*feature/this-is-a-new-feature-branch* - in case no related item exists
+
+## Bugs
+
+*bugfix/name-of-the-bug*
+
+## Release
+
+Git flow for releases is work in progress, will be added her eeventually
+
+*release/1.0.0* - cut from main when ready

--- a/docs/baseline-protocol-code/branch-naming.md
+++ b/docs/baseline-protocol-code/branch-naming.md
@@ -18,6 +18,6 @@
 
 ## Release
 
-Git flow for releases is work in progress, will be added her eeventually
+Git flow for releases is work in progress, will be added here eventually
 
 *release/1.0.0* - cut from main when ready

--- a/docs/baseline-protocol-code/branch-naming.md
+++ b/docs/baseline-protocol-code/branch-naming.md
@@ -6,19 +6,18 @@
 
 ## Feature
 
-*feature/XYZ-this-is-a-new-feature-branch* - related issue XYZ.
+*feature/XYZ-this-is-a-new-feature-branch* - related issue with number id XYZ.
 
 *feature/BLIP-#-repo-branch-standards* - related BLIP-#.
 
 ## Bugs
 
-*bugfix/XYZ-name-of-the-bug* - related issue XYZ.
-
+*bugfix/XYZ-name-of-the-bug* - related issue with number id XYZ.
 ## Hotfix
 
 Hotfix is branched from the release branch.
 
-*hotfix/XYZ-this-is-a-hotfix* - related issue XYZ.
+*hotfix/XYZ-this-is-a-hotfix* - related issue with number id XYZ.
 
 ## Release
 

--- a/docs/baseline-protocol-code/branch-naming.md
+++ b/docs/baseline-protocol-code/branch-naming.md
@@ -10,8 +10,8 @@
 
 *feature/BLIP-#-repo-branch-standards* - related BLIP-#.
 
-Note: *When working on a branch that covers multiple issues and\or bugs, use the main one for the name of the branch but make sure
-to link all of the affected issues before merging the PR.*
+Note: *When working on a branch that covers multiple issues or blips, use the main one for the name of the branch but make sure
+to link all related ones before merging the PR.*
 
 ## Bugs
 

--- a/docs/baseline-protocol-code/branch-naming.md
+++ b/docs/baseline-protocol-code/branch-naming.md
@@ -2,22 +2,26 @@
 
 ## Main
 
-*main* - main development branch, feature and release branches branched from it, changes only through the PR process.
+*main* - main development branch, feature, bugfix and release branches branched from it. Changes only through the PR process.
 
 ## Feature
 
-*feature/XYZ-this-is-a-new-feature-branch* - in case related issue XYZ exists
+*feature/XYZ-this-is-a-new-feature-branch* - related issue XYZ.
 
-*feature/BLIP-#-repo-branch-standards* - in case related BLIP-# exists
-
-*feature/this-is-a-new-feature-branch* - in case no related item exists
+*feature/BLIP-#-repo-branch-standards* - related BLIP-#.
 
 ## Bugs
 
-*bugfix/name-of-the-bug*
+*bugfix/XYZ-name-of-the-bug* - related issue XYZ.
+
+## Hotfix
+
+Hotfix is branched from the release branch.
+
+*hotfix/XYZ-this-is-a-hotfix* - related issue XYZ.
 
 ## Release
 
-Git flow for releases is work in progress, will be added here eventually
+Git flow for releases is work in progress, will be added here eventually.
 
 *release/1.0.0* - cut from main when ready

--- a/docs/baseline-protocol-code/developer-resources.md
+++ b/docs/baseline-protocol-code/developer-resources.md
@@ -2,11 +2,12 @@
 
 If you want to build with the Baseline Protocol, you will find these helpful:
 
-| Resource                    | Quick Access                                                                                               |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| v1.0 Codebase Documentation | [Here](packages/)                                                                                          |
-| v1.0 Codebase               | [Here](https://github.com/eea-oasis/baseline/tree/master/core)                                             |
-| Developer Quickstart        | [Here](https://docs.provide.services/api/quickstart/cli-quickstart)                                        |
-| Implementation Guide        | Soon                                                                                                       |
-| Developer Slack Channel     | [Here](https://join.slack.com/t/ethereum-baseline/shared\_invite/zt-d6emqeci-bjzBsXBqK4D7tBTZ40AEfQ): #dev |
-| Reference Implementations   | [Here](../bri/overview-of-reference-implementations.md)                                                    |
+| Resource                     | Quick Access                                                                                               |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| v1.0 Code base documentation | [Here](packages/)                                                                                          |
+| v1.0 Code base               | [Here](https://github.com/eea-oasis/baseline/tree/master/core)                                             |
+| Branch naming standard        | [Here] (./branch-naming.md)                                                    |                                        |
+| Implementation guide         | Soon                                                                                                       |
+| Developers slack channel     | [Here](https://join.slack.com/t/ethereum-baseline/shared\_invite/zt-d6emqeci-bjzBsXBqK4D7tBTZ40AEfQ): #dev |
+| Reference implementations    | [Here](../bri/overview-of-reference-implementations.md)                                                    |
+


### PR DESCRIPTION
# Description

Adds branch naming standard to docs

## Related Issue

[BLIP-9](https://github.com/eea-oasis/baseline-blips/issues/11)

## Motivation and Context

There was no standard defined previoulsy.

## How Has This Been Tested

Will be tested with docs deployment.

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ X] I commit to abide by the Responsibilities of Code Owners/Maintainers.
