### PR TITLE
Removal of maintainer due to inactivity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @skarred14 @kthomas @ognjenkurtic @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern
+*       @skarred14 @ognjenkurtic @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern


### PR DESCRIPTION

<!--- Describe your changes in detail -->
Removal of Maintainer due to inactivity in Baseline Core Devs.

## Related Issue
https://github.com/eea-oasis/baseline/pull/494

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

@kthomas please resubmit in the future if you are interested in being a Maintainer again, according to the [Maintainer Governance](https://docs.baseline-protocol.org/community/maintainers)
# Description

## How Has This Been Tested

## Screenshots (if appropriate)

## Types of changes

Removal of maintainer from code owners list to due inactivity 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
