### PR TITLE
Feature/628 parse incoming nats messages

### DIFF
--- a/examples/bri-3/README.md
+++ b/examples/bri-3/README.md
@@ -86,6 +86,7 @@ Run the following commands in the terminal:
 $ nats context add local --description "Localhost" # adds localhost server to nats cli
 
 $ nats pub general "<message>" # publishes new message on the general subject
+# Example message format: "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"fromBpiSubjectId\": \"8af52beb-bda4-404b-b1e0-a5e0afa394b5\", \"toBpiSubjectId\": \"16f74e4c-27d6-4bbb-81d6-23236cac0252\", \"content\": null, \"signature\": \"xyz\", \"type\": 0}"
 
 ```
 Observe the log messages in the terminal where the app is running.

--- a/examples/bri-3/README.md
+++ b/examples/bri-3/README.md
@@ -86,7 +86,7 @@ Run the following commands in the terminal:
 $ nats context add local --description "Localhost" # adds localhost server to nats cli
 
 $ nats pub general "<message>" # publishes new message on the general subject
-# Example message format: "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"fromBpiSubjectId\": \"8af52beb-bda4-404b-b1e0-a5e0afa394b5\", \"toBpiSubjectId\": \"16f74e4c-27d6-4bbb-81d6-23236cac0252\", \"content\": null, \"signature\": \"xyz\", \"type\": 0}"
+# Example message format: "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}"
 
 ```
 Observe the log messages in the terminal where the app is running.

--- a/examples/bri-3/src/bri/auth/guards/didJwt.guard.ts
+++ b/examples/bri-3/src/bri/auth/guards/didJwt.guard.ts
@@ -84,7 +84,7 @@ export class DidJwtAuthGuard implements CanActivate {
     if (!authorization || Array.isArray(authorization)) {
       throw new Error('Invalid Authorization Header');
     }
-    const [_, token] = authorization.split(' ');
+    const [, token] = authorization.split(' ');
     return token;
   }
 }

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -46,6 +46,7 @@ export class BpiMessageAgent {
     const bpiMessageToUpdate: BpiMessage =
       await this.bpiMessageStorageAgent.getBpiMessageById(id);
 
+    // TODO: throw should not happen in the storage agent
     if (!bpiMessageToUpdate) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
     }

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -16,17 +16,14 @@ export class BpiMessageAgent {
   public async getFromAndToSubjectsAndThrowIfNotExist(
     fromBpiSubjectId: string,
     toBpiSubjectId: string,
-  ) {
+  ): Promise<[BpiSubject, BpiSubject]> {
     const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       fromBpiSubjectId,
     );
     const toBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       toBpiSubjectId,
     );
-    return {
-      fromBpiSubject,
-      toBpiSubject,
-    };
+    return [fromBpiSubject, toBpiSubject];
   }
 
   public createNewBpiMessage(

--- a/examples/bri-3/src/bri/communication/agents/bpiMessagesStorage.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessagesStorage.agent.ts
@@ -32,7 +32,7 @@ export class BpiMessageStorageAgent extends PrismaService {
     });
   }
 
-  async createNewBpiMessage(bpiMessage: BpiMessage): Promise<BpiMessage> {
+  async storeNewBpiMessage(bpiMessage: BpiMessage): Promise<BpiMessage> {
     const newBpiMessageModel = await this.message.create({
       data: {
         id: bpiMessage.id,

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -1,17 +1,13 @@
-import { CreateBpiMessageDto } from '../api/dtos/request/createBpiMessage.dto';
 import { MessagingAgent } from './messaging.agent';
 
 describe('Messaging Agent', () => {
   it('Should return error when validating incorrect JSON raw message', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage = 'test';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [resultDto, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -24,15 +20,12 @@ describe('Messaging Agent', () => {
 
   it('Should return error when validating correct JSON raw message with invalid GUID in id field', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "pakakoto", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -42,15 +35,12 @@ describe('Messaging Agent', () => {
 
   it('Should return error when validating correct JSON raw message with invalid GUID in from field', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "7123", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -60,15 +50,12 @@ describe('Messaging Agent', () => {
 
   it('Should return error when validating correct JSON raw message with invalid GUID in to field', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "msm24", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -78,15 +65,12 @@ describe('Messaging Agent', () => {
 
   it('Should return error when validating correct JSON raw message with content field not valid JSON', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": 123, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -96,15 +80,12 @@ describe('Messaging Agent', () => {
 
   it('Should return error when validating correct JSON raw message with signature field empty', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -114,15 +95,12 @@ describe('Messaging Agent', () => {
 
   it('Should return error when validating correct JSON raw message with message type not being info', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
@@ -132,15 +110,12 @@ describe('Messaging Agent', () => {
 
   it('Should return no errors and create message dto when validating correct JSON raw message', () => {
     // Arrange
-    let resultDto: CreateBpiMessageDto;
-    let validationErrors: string[] = [];
-
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] =
+    const [resultDto, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -1,140 +1,157 @@
-import { CreateBpiMessageDto } from "../api/dtos/request/createBpiMessage.dto";
-import { MessagingAgent } from "./messaging.agent";
+import { CreateBpiMessageDto } from '../api/dtos/request/createBpiMessage.dto';
+import { MessagingAgent } from './messaging.agent';
 
 describe('Messaging Agent', () => {
   it('Should return error when validating incorrect JSON raw message', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "test";
+
+    const rawMessage = 'test';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(resultDto).toBeUndefined();
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("test is not valid JSON. Error: SyntaxError: Unexpected token e in JSON at position 1");
+    expect(validationErrors[0]).toEqual(
+      'test is not valid JSON. Error: SyntaxError: Unexpected token e in JSON at position 1',
+    );
   });
 
   it('Should return error when validating correct JSON raw message with invalid GUID in id field', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"pakakoto\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    const rawMessage =
+      '{ "id": "pakakoto", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("id pakakoto is not a valid UUID");
+    expect(validationErrors[0]).toEqual('id pakakoto is not a valid UUID');
   });
 
   it('Should return error when validating correct JSON raw message with invalid GUID in from field', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"7123\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "7123", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("from 7123 is not a valid UUID");
+    expect(validationErrors[0]).toEqual('from 7123 is not a valid UUID');
   });
 
   it('Should return error when validating correct JSON raw message with invalid GUID in to field', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"msm24\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "msm24", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("to msm24 is not a valid UUID");
+    expect(validationErrors[0]).toEqual('to msm24 is not a valid UUID');
   });
 
   it('Should return error when validating correct JSON raw message with content field not valid JSON', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": 123, \"signature\": \"xyz\", \"type\": 0}";
+
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": 123, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("content: 123 is not valid JSON.");
+    expect(validationErrors[0]).toEqual('content: 123 is not valid JSON.');
   });
 
   it('Should return error when validating correct JSON raw message with signature field empty', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"\", \"type\": 0}";
+
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("signature is empty");
+    expect(validationErrors[0]).toEqual('signature is empty');
   });
 
   it('Should return error when validating correct JSON raw message with message type not being info', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 1}";
+
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual("type is unknown 1");
+    expect(validationErrors[0]).toEqual('type is unknown 1');
   });
 
   it('Should return no errors and create message dto when validating correct JSON raw message', () => {
     // Arrange
     let resultDto: CreateBpiMessageDto;
     let validationErrors: string[] = [];
-    
-    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const messagingAgent = new MessagingAgent(null, null, null);
-    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+    [resultDto, validationErrors] =
+      messagingAgent.validateBpiMessageFormat(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(0);
     expect(resultDto).toBeDefined();
-    expect(resultDto.id).toEqual("0a3dd67c-c031-4b50-95df-0bc5fc1c78b5");
-    expect(resultDto.from).toEqual("71302cec-0a38-469a-a4e5-f58bdfc4ab32");
-    expect(resultDto.to).toEqual("76cdd901-d87d-4c87-b572-155afe45c128");
+    expect(resultDto.id).toEqual('0a3dd67c-c031-4b50-95df-0bc5fc1c78b5');
+    expect(resultDto.from).toEqual('71302cec-0a38-469a-a4e5-f58bdfc4ab32');
+    expect(resultDto.to).toEqual('76cdd901-d87d-4c87-b572-155afe45c128');
     // TODO: Find a fix for the escape character
     // expect(resultDto.content).toEqual("{ \"testProp\": \"testValue\" }");
-    expect(resultDto.signature).toEqual("xyz");
+    expect(resultDto.signature).toEqual('xyz');
     expect(resultDto.type).toEqual(0);
   });
 });

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -1,0 +1,140 @@
+import { CreateBpiMessageDto } from "../api/dtos/request/createBpiMessage.dto";
+import { MessagingAgent } from "./messaging.agent";
+
+describe('Messaging Agent', () => {
+  it('Should return error when validating incorrect JSON raw message', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "test";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(resultDto).toBeUndefined();
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("test is not valid JSON. Error: SyntaxError: Unexpected token e in JSON at position 1");
+  });
+
+  it('Should return error when validating correct JSON raw message with invalid GUID in id field', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"pakakoto\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("id pakakoto is not a valid UUID");
+  });
+
+  it('Should return error when validating correct JSON raw message with invalid GUID in from field', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"7123\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("from 7123 is not a valid UUID");
+  });
+
+  it('Should return error when validating correct JSON raw message with invalid GUID in to field', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"msm24\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("to msm24 is not a valid UUID");
+  });
+
+  it('Should return error when validating correct JSON raw message with content field not valid JSON', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": 123, \"signature\": \"xyz\", \"type\": 0}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("content: 123 is not valid JSON.");
+  });
+
+  it('Should return error when validating correct JSON raw message with signature field empty', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"\", \"type\": 0}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("signature is empty");
+  });
+
+  it('Should return error when validating correct JSON raw message with message type not being info', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 1}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(1);
+    expect(validationErrors[0]).toEqual("type is unknown 1");
+  });
+
+  it('Should return no errors and create message dto when validating correct JSON raw message', () => {
+    // Arrange
+    let resultDto: CreateBpiMessageDto;
+    let validationErrors: string[] = [];
+    
+    const rawMessage = "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}";
+
+    // Act
+    const messagingAgent = new MessagingAgent(null, null, null);
+    [resultDto, validationErrors] = messagingAgent.validateBpiMessageFormat(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(0);
+    expect(resultDto).toBeDefined();
+    expect(resultDto.id).toEqual("0a3dd67c-c031-4b50-95df-0bc5fc1c78b5");
+    expect(resultDto.from).toEqual("71302cec-0a38-469a-a4e5-f58bdfc4ab32");
+    expect(resultDto.to).toEqual("76cdd901-d87d-4c87-b572-155afe45c128");
+    // TODO: Find a fix for the escape character
+    // expect(resultDto.content).toEqual("{ \"testProp\": \"testValue\" }");
+    expect(resultDto.signature).toEqual("xyz");
+    expect(resultDto.type).toEqual(0);
+  });
+});

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -23,7 +23,7 @@ describe('Messaging Agent', () => {
     );
   });
 
-  it('Should return error when validating correct JSON raw message with invalid GUID in id field', () => {
+  it('Should return error when validating correct JSON raw message with invalid UUID in id field', () => {
     // Arrange
     const rawMessage =
       '{ "id": "pakakoto", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
@@ -37,7 +37,7 @@ describe('Messaging Agent', () => {
     expect(validationErrors[0]).toEqual('id pakakoto is not a valid UUID');
   });
 
-  it('Should return error when validating correct JSON raw message with invalid GUID in from field', () => {
+  it('Should return error when validating correct JSON raw message with invalid UUID in from field', () => {
     // Arrange
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "7123", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
@@ -51,7 +51,7 @@ describe('Messaging Agent', () => {
     expect(validationErrors[0]).toEqual('from 7123 is not a valid UUID');
   });
 
-  it('Should return error when validating correct JSON raw message with invalid GUID in to field', () => {
+  it('Should return error when validating correct JSON raw message with invalid UUID in to field', () => {
     // Arrange
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "msm24", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -1,12 +1,17 @@
 import { MessagingAgent } from './messaging.agent';
 
+let messagingAgent: MessagingAgent;
+
+beforeAll(async () => {
+  messagingAgent = new MessagingAgent(null, null, null);
+});
+
 describe('Messaging Agent', () => {
   it('Should return error when validating incorrect JSON raw message', () => {
     // Arrange
     const rawMessage = 'test';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [resultDto, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -24,7 +29,6 @@ describe('Messaging Agent', () => {
       '{ "id": "pakakoto", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -39,7 +43,6 @@ describe('Messaging Agent', () => {
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "7123", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -54,7 +57,6 @@ describe('Messaging Agent', () => {
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "msm24", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -69,7 +71,6 @@ describe('Messaging Agent', () => {
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": 123, "signature": "xyz", "type": 0}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -84,7 +85,6 @@ describe('Messaging Agent', () => {
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "", "type": 0}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -99,7 +99,6 @@ describe('Messaging Agent', () => {
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 
@@ -114,7 +113,6 @@ describe('Messaging Agent', () => {
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
-    const messagingAgent = new MessagingAgent(null, null, null);
     const [resultDto, validationErrors] =
       messagingAgent.validateBpiMessageFormat(rawMessage);
 

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -34,7 +34,7 @@ describe('Messaging Agent', () => {
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual('id pakakoto is not a valid UUID');
+    expect(validationErrors[0]).toEqual('id: pakakoto is not a valid UUID');
   });
 
   it('Should return error when validating correct JSON raw message with invalid UUID in from field', () => {
@@ -48,7 +48,7 @@ describe('Messaging Agent', () => {
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual('from 7123 is not a valid UUID');
+    expect(validationErrors[0]).toEqual('from: 7123 is not a valid UUID');
   });
 
   it('Should return error when validating correct JSON raw message with invalid UUID in to field', () => {
@@ -62,7 +62,7 @@ describe('Messaging Agent', () => {
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual('to msm24 is not a valid UUID');
+    expect(validationErrors[0]).toEqual('to: msm24 is not a valid UUID');
   });
 
   it('Should return error when validating correct JSON raw message with content field not valid JSON', () => {
@@ -104,7 +104,7 @@ describe('Messaging Agent', () => {
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual('type is unknown 1');
+    expect(validationErrors[0]).toEqual('type: 1 is unknown');
   });
 
   it('Should return no errors and create message dto when validating correct JSON raw message', () => {

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -122,8 +122,7 @@ describe('Messaging Agent', () => {
     expect(resultDto.id).toEqual('0a3dd67c-c031-4b50-95df-0bc5fc1c78b5');
     expect(resultDto.from).toEqual('71302cec-0a38-469a-a4e5-f58bdfc4ab32');
     expect(resultDto.to).toEqual('76cdd901-d87d-4c87-b572-155afe45c128');
-    // TODO: Find a fix for the escape character
-    // expect(resultDto.content).toEqual("{ \"testProp\": \"testValue\" }");
+    expect(resultDto.content).toEqual({ testProp: 'testValue' });
     expect(resultDto.signature).toEqual('xyz');
     expect(resultDto.type).toEqual(0);
   });

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -57,7 +57,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     );
   }
 
-  private validateBpiMessageFormat(
+  public validateBpiMessageFormat(
     rawMessage: string,
   ): [CreateBpiMessageDto, string[]] {
     const errors: string[] = [];
@@ -76,13 +76,13 @@ export class MessagingAgent implements OnApplicationBootstrap {
 
     if (!validate(newBpiMessageCandidate.from)) {
       errors.push(
-        `fromBpiSubjectId ${newBpiMessageCandidate.from} is not a valid UUID`,
+        `from ${newBpiMessageCandidate.from} is not a valid UUID`,
       );
     }
 
     if (!validate(newBpiMessageCandidate.to)) {
       errors.push(
-        `toBpiSubjectId ${newBpiMessageCandidate.to} is not a valid UUID`,
+        `to ${newBpiMessageCandidate.to} is not a valid UUID`,
       );
     }
 

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -71,15 +71,15 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
 
     if (!validate(newBpiMessageCandidate.id)) {
-      errors.push(`id ${newBpiMessageCandidate.id} is not a valid UUID`);
+      errors.push(`id: ${newBpiMessageCandidate.id} is not a valid UUID`);
     }
 
     if (!validate(newBpiMessageCandidate.from)) {
-      errors.push(`from ${newBpiMessageCandidate.from} is not a valid UUID`);
+      errors.push(`from: ${newBpiMessageCandidate.from} is not a valid UUID`);
     }
 
     if (!validate(newBpiMessageCandidate.to)) {
-      errors.push(`to ${newBpiMessageCandidate.to} is not a valid UUID`);
+      errors.push(`to: ${newBpiMessageCandidate.to} is not a valid UUID`);
     }
 
     if (
@@ -99,7 +99,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
 
     if (newBpiMessageCandidate.type !== BpiMessageType.Info) {
-      errors.push(`type is unknown ${newBpiMessageCandidate.type}`);
+      errors.push(`type: ${newBpiMessageCandidate.type} is unknown`);
     }
 
     return [newBpiMessageCandidate, errors];

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -36,7 +36,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
       this.validateBpiMessageFormat(rawMessage);
 
     if (validationErrors.length > 0) {
-      this.logger.logWarn(
+      this.logger.logError(
         `MessagingListenerAgent: Failed parsing message into Bpi Message. Errors: ${validationErrors.join(
           '; ',
         )}`,
@@ -64,7 +64,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     let newBpiMessageCandidate: CreateBpiMessageDto;
 
     try {
-      newBpiMessageCandidate = JSON.parse(rawMessage); // TODO: Make it more robust (i.e JSON.parse(123) does not throw)
+      newBpiMessageCandidate = this.parseJsonOrThrow(rawMessage);
     } catch (e) {
       errors.push(`${rawMessage} is not valid JSON. Error: ${e}`);
       return [newBpiMessageCandidate, errors];
@@ -87,7 +87,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
 
     try {
-      JSON.parse(newBpiMessageCandidate.content); // TODO: Make it more robust (i.e JSON.parse(123) does not throw)
+      this.parseJsonOrThrow(newBpiMessageCandidate.content);
     } catch (e) {
       errors.push(
         `content: ${newBpiMessageCandidate.content} is not valid JSON. Error: ${e}`,
@@ -107,4 +107,15 @@ export class MessagingAgent implements OnApplicationBootstrap {
 
     return [newBpiMessageCandidate, errors];
   }
+
+  private parseJsonOrThrow(jsonString: string) {
+    // https://stackoverflow.com/questions/3710204/how-to-check-if-a-string-is-a-valid-json-string
+    const o = JSON.parse(jsonString);
+    
+    if (o && typeof o === "object") {
+      return o;
+    }
+
+    throw new Error(`String ${jsonString} is a valid JSON primitive but not a proper JSON document.`);
+  };
 }

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -1,8 +1,11 @@
 import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
+import { isUuid } from 'uuidv4';
 import { LoggingService } from '../../../shared/logging/logging.service';
-import { ProcessInboundMessageCommand } from '../capabilities/processInboundMessage/processInboundMessage.command';
+import { ProcessInboundBpiMessageCommand } from '../capabilities/processInboundMessage/processInboundMessage.command';
 import { IMessagingClient } from '../messagingClients/messagingClient.interface';
+import { BpiMessage } from '../models/bpiMessage';
+import { BpiMessageType } from '../models/bpiMessageType.enum';
 
 @Injectable()
 export class MessagingAgent implements OnApplicationBootstrap {
@@ -26,8 +29,68 @@ export class MessagingAgent implements OnApplicationBootstrap {
 
   private onNewMessageReceived(rawMessage: string): void {
     this.logger.logInfo(
-      `MessagingListenerAgent: New raw message received: ${rawMessage}. Dispatching ProcessInboundMessageCommand`,
+      `MessagingListenerAgent: New raw message received: ${rawMessage}. Trying to parse into a Bpi Message`,
     );
-    this.commandBus.execute(new ProcessInboundMessageCommand(rawMessage));
+
+    const [newBpiMessageCandidate, validationErrors] = this.validateBpiMessageFormat(
+      rawMessage,
+    );
+
+    if (validationErrors.length > 0) {
+      this.logger.logWarn(
+        `MessagingListenerAgent: Failed parsing message into Bpi Message. Errors: ${validationErrors.join(
+          '; ',
+        )}`,
+      );
+
+      return;
+    }
+
+    this.commandBus.execute(
+      new ProcessInboundBpiMessageCommand(newBpiMessageCandidate),
+    );
+  }
+
+  private validateBpiMessageFormat(rawMessage: string): [BpiMessage, string[]] {
+    const errors: string[] = [];
+    let newBpiMessageCandidate: BpiMessage;
+
+    try {
+      newBpiMessageCandidate = JSON.parse(rawMessage) // TODO: Make it more robust (i.e JSON.parse(123) does not throw)
+    } catch (e) {
+      errors.push(`${rawMessage} is not valid JSON. Error: ${e}`);
+      return [newBpiMessageCandidate, errors];
+    }
+    
+    if (!isUuid(newBpiMessageCandidate.id)) {
+      errors.push('id is not a valid UUID');
+    }
+
+    if (!isUuid(newBpiMessageCandidate.fromBpiSubjectId)) {
+      errors.push('fromBpiSubjectId is not a valid UUID');
+    }
+
+    if (!isUuid(newBpiMessageCandidate.toBpiSubjectId)) {
+      errors.push('toBpiSubjectId is not a valid UUID');
+    }
+
+    try {
+      JSON.parse(newBpiMessageCandidate.content); // TODO: Make it more robust (i.e JSON.parse(123) does not throw)
+    } catch (e) {
+      errors.push(`content: ${newBpiMessageCandidate.content} is not valid JSON. Error: ${e}`);
+    }
+
+    if (!newBpiMessageCandidate.signature || newBpiMessageCandidate.signature.length === 0) {
+      errors.push('signature is empty');
+    }
+
+    if (
+      newBpiMessageCandidate.type !== BpiMessageType.MessageType1 &&
+      newBpiMessageCandidate.type !== BpiMessageType.MessageType2
+    ) {
+      errors.push(`type is unknown ${newBpiMessageCandidate.type}`);
+    }
+
+    return [newBpiMessageCandidate, errors];
   }
 }

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -75,18 +75,17 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
 
     if (!validate(newBpiMessageCandidate.from)) {
-      errors.push(
-        `from ${newBpiMessageCandidate.from} is not a valid UUID`,
-      );
+      errors.push(`from ${newBpiMessageCandidate.from} is not a valid UUID`);
     }
 
     if (!validate(newBpiMessageCandidate.to)) {
-      errors.push(
-        `to ${newBpiMessageCandidate.to} is not a valid UUID`,
-      );
+      errors.push(`to ${newBpiMessageCandidate.to} is not a valid UUID`);
     }
 
-    if (!newBpiMessageCandidate.content || typeof newBpiMessageCandidate.content !== "object") {
+    if (
+      !newBpiMessageCandidate.content ||
+      typeof newBpiMessageCandidate.content !== 'object'
+    ) {
       errors.push(
         `content: ${newBpiMessageCandidate.content} is not valid JSON.`,
       );
@@ -109,11 +108,13 @@ export class MessagingAgent implements OnApplicationBootstrap {
   private parseJsonOrThrow(jsonString: string) {
     // https://stackoverflow.com/questions/3710204/how-to-check-if-a-string-is-a-valid-json-string
     const o = JSON.parse(jsonString);
-    
-    if (o && typeof o === "object") {
+
+    if (o && typeof o === 'object') {
       return o;
     }
 
-    throw new Error(`String ${jsonString} is a valid JSON primitive but not a proper JSON document.`);
-  };
+    throw new Error(
+      `String ${jsonString} is a valid JSON primitive but not a proper JSON document.`,
+    );
+  }
 }

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -50,7 +50,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
         newBpiMessageCandidate.id,
         newBpiMessageCandidate.from,
         newBpiMessageCandidate.to,
-        newBpiMessageCandidate.content,
+        JSON.stringify(newBpiMessageCandidate.content),
         newBpiMessageCandidate.signature,
         newBpiMessageCandidate.type,
       ),
@@ -86,11 +86,9 @@ export class MessagingAgent implements OnApplicationBootstrap {
       );
     }
 
-    try {
-      this.parseJsonOrThrow(newBpiMessageCandidate.content);
-    } catch (e) {
+    if (!newBpiMessageCandidate.content || typeof newBpiMessageCandidate.content !== "object") {
       errors.push(
-        `content: ${newBpiMessageCandidate.content} is not valid JSON. Error: ${e}`,
+        `content: ${newBpiMessageCandidate.content} is not valid JSON.`,
       );
     }
 

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -63,15 +63,15 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
     
     if (!isUuid(newBpiMessageCandidate.id)) {
-      errors.push('id is not a valid UUID');
+      errors.push(`id ${newBpiMessageCandidate.id} is not a valid UUID`);
     }
 
     if (!isUuid(newBpiMessageCandidate.fromBpiSubjectId)) {
-      errors.push('fromBpiSubjectId is not a valid UUID');
+      errors.push(`fromBpiSubjectId ${newBpiMessageCandidate.fromBpiSubjectId} is not a valid UUID`);
     }
 
     if (!isUuid(newBpiMessageCandidate.toBpiSubjectId)) {
-      errors.push('toBpiSubjectId is not a valid UUID');
+      errors.push(`toBpiSubjectId ${newBpiMessageCandidate.toBpiSubjectId} is not a valid UUID`);
     }
 
     try {
@@ -85,8 +85,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
 
     if (
-      newBpiMessageCandidate.type !== BpiMessageType.MessageType1 &&
-      newBpiMessageCandidate.type !== BpiMessageType.MessageType2
+      newBpiMessageCandidate.type !== BpiMessageType.Info
     ) {
       errors.push(`type is unknown ${newBpiMessageCandidate.type}`);
     }

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
-import { isUuid } from 'uuidv4';
+import { validate } from 'uuid';
 import { LoggingService } from '../../../shared/logging/logging.service';
 import { ProcessInboundBpiMessageCommand } from '../capabilities/processInboundMessage/processInboundMessage.command';
 import { IMessagingClient } from '../messagingClients/messagingClient.interface';
@@ -62,15 +62,15 @@ export class MessagingAgent implements OnApplicationBootstrap {
       return [newBpiMessageCandidate, errors];
     }
     
-    if (!isUuid(newBpiMessageCandidate.id)) {
+    if (!validate(newBpiMessageCandidate.id)) {
       errors.push(`id ${newBpiMessageCandidate.id} is not a valid UUID`);
     }
 
-    if (!isUuid(newBpiMessageCandidate.fromBpiSubjectId)) {
+    if (!validate(newBpiMessageCandidate.fromBpiSubjectId)) {
       errors.push(`fromBpiSubjectId ${newBpiMessageCandidate.fromBpiSubjectId} is not a valid UUID`);
     }
 
-    if (!isUuid(newBpiMessageCandidate.toBpiSubjectId)) {
+    if (!validate(newBpiMessageCandidate.toBpiSubjectId)) {
       errors.push(`toBpiSubjectId ${newBpiMessageCandidate.toBpiSubjectId} is not a valid UUID`);
     }
 

--- a/examples/bri-3/src/bri/communication/agents/mockBpiMessagesStorage.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/mockBpiMessagesStorage.agent.ts
@@ -18,7 +18,7 @@ export class MockBpiMessageStorageAgent {
     return Promise.resolve(this.bpiMessagesStore);
   }
 
-  async createNewBpiMessage(bpiMessage: BpiMessage): Promise<BpiMessage> {
+  async storeNewBpiMessage(bpiMessage: BpiMessage): Promise<BpiMessage> {
     const createdBpiMessage = new BpiMessage(
       bpiMessage.id,
       bpiMessage.fromBpiSubject,

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -15,7 +15,7 @@ export class CreateBpiMessageCommandHandler
   ) {}
 
   async execute(command: CreateBpiMessageCommand) {
-    const { fromBpiSubject, toBpiSubject } =
+    const [fromBpiSubject, toBpiSubject] =
       await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
         command.from,
         command.to,

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -30,7 +30,7 @@ export class CreateBpiMessageCommandHandler
       command.type,
     );
 
-    const newBpiMessage = await this.storageAgent.createNewBpiMessage(
+    const newBpiMessage = await this.storageAgent.storeNewBpiMessage(
       newBpiMessageCandidate,
     );
 

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessage.command.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessage.command.ts
@@ -1,3 +1,5 @@
-export class ProcessInboundMessageCommand {
-  constructor(public readonly rawMessage: string) {}
+import { BpiMessage } from '../../models/bpiMessage';
+
+export class ProcessInboundBpiMessageCommand {
+  constructor(public readonly bpiMessage: BpiMessage) {}
 }

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessage.command.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessage.command.ts
@@ -1,5 +1,12 @@
-import { BpiMessage } from '../../models/bpiMessage';
+import { BpiMessageType } from '../../models/bpiMessageType.enum';
 
 export class ProcessInboundBpiMessageCommand {
-  constructor(public readonly bpiMessage: BpiMessage) {}
+  constructor(
+    public readonly id: string,
+    public readonly from: string,
+    public readonly to: string,
+    public readonly content: string,
+    public readonly signature: string,
+    public readonly type: BpiMessageType,
+  ) {}
 }

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -16,19 +16,15 @@ export class ProcessInboundMessageCommandHandler
   ) {}
 
   async execute(command: ProcessInboundBpiMessageCommand) {
-    let dbFromBpiSubject: BpiSubject;
-    let dbToBpiSubject: BpiSubject;
+    let fromBpiSubject: BpiSubject;
+    let toBpiSubject: BpiSubject;
 
     try {
-      const { fromBpiSubject, toBpiSubject } =
+      [fromBpiSubject, toBpiSubject] =
         await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
           command.from,
           command.to,
         );
-
-      // TODO: Better way to map this
-      dbFromBpiSubject = fromBpiSubject;
-      dbToBpiSubject = toBpiSubject;
     } catch (e) {
       // TODO: Log and ignore message
       return;
@@ -36,8 +32,8 @@ export class ProcessInboundMessageCommandHandler
 
     const newBpiMessageCandidate = this.agent.createNewBpiMessage(
       command.id,
-      dbFromBpiSubject,
-      dbToBpiSubject,
+      fromBpiSubject,
+      toBpiSubject,
       command.content,
       command.signature,
       command.type,

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -1,16 +1,16 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { LoggingService } from '../../../../shared/logging/logging.service';
-import { ProcessInboundMessageCommand } from './processInboundMessage.command';
+import { ProcessInboundBpiMessageCommand } from './processInboundMessage.command';
 
-@CommandHandler(ProcessInboundMessageCommand)
+@CommandHandler(ProcessInboundBpiMessageCommand)
 export class ProcessInboundMessageCommandHandler
-  implements ICommandHandler<ProcessInboundMessageCommand>
+  implements ICommandHandler<ProcessInboundBpiMessageCommand>
 {
   constructor(private readonly log: LoggingService) {}
 
-  async execute(command: ProcessInboundMessageCommand) {
+  async execute(command: ProcessInboundBpiMessageCommand) {
     this.log.logInfo(
-      `ProcessInboundMessageCommandHandler: I will be responsible to process this raw message ${command.rawMessage}`,
+      `ProcessInboundMessageCommandHandler: Processing BPI message with id ${command.bpiMessage.id}`,
     );
   }
 }

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -1,6 +1,6 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { BpiSubject } from 'src/bri/identity/bpiSubjects/models/bpiSubject';
-import { LoggingService } from 'src/shared/logging/logging.service';
+import { LoggingService } from '../../../../shared/logging/logging.service';
+import { BpiSubject } from '../../../identity/bpiSubjects/models/bpiSubject';
 import { BpiMessageAgent } from '../../agents/bpiMessages.agent';
 import { BpiMessageStorageAgent } from '../../agents/bpiMessagesStorage.agent';
 import { ProcessInboundBpiMessageCommand } from './processInboundMessage.command';

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -1,4 +1,5 @@
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { BpiSubject } from 'src/bri/identity/bpiSubjects/models/bpiSubject';
 import { BpiMessageAgent } from '../../agents/bpiMessages.agent';
 import { BpiMessageStorageAgent } from '../../agents/bpiMessagesStorage.agent';
 import { ProcessInboundBpiMessageCommand } from './processInboundMessage.command';
@@ -12,16 +13,29 @@ export class ProcessInboundMessageCommandHandler
     private readonly storageAgent: BpiMessageStorageAgent) {}
 
   async execute(command: ProcessInboundBpiMessageCommand) {
-    const { fromBpiSubject, toBpiSubject } =
-      await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
-        command.bpiMessage.fromBpiSubjectId,
-        command.bpiMessage.toBpiSubjectId,
-      );
+    let dbFromBpiSubject: BpiSubject;
+    let dbToBpiSubject: BpiSubject;
+    
+    try {
+      const { fromBpiSubject, toBpiSubject } =
+        await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
+          command.bpiMessage.fromBpiSubjectId,
+          command.bpiMessage.toBpiSubjectId,
+        );
+      
+        // TODO: Better way to map this
+        dbFromBpiSubject = fromBpiSubject;
+        dbToBpiSubject = toBpiSubject;
+    } catch (e) {
+      // TODO: Log and ignore message
+      return;
+    }
+    
 
     const newBpiMessageCandidate = this.agent.createNewBpiMessage(
       command.bpiMessage.id,
-      fromBpiSubject,
-      toBpiSubject,
+      dbFromBpiSubject,
+      dbToBpiSubject,
       command.bpiMessage.content,
       command.bpiMessage.signature,
       command.bpiMessage.type,

--- a/examples/bri-3/src/bri/communication/models/bpiMessageType.enum.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessageType.enum.ts
@@ -1,5 +1,3 @@
 export enum BpiMessageType {
-  // TODO: Add proper types as we move forward
-  MessageType1,
-  MessageType2,
+  Info,
 }


### PR DESCRIPTION
# Description

This PR introduces parsing of raw string messages coming via NATS (or other clients in the future), validating it for a proper dto object for message creation and dispatching a command which triggers creation and  storage of the BPI Message in the DB. Content signatures, message proxying and other concepts will come as separate issues and are not in scope.

## Related Issue

#628 

## Motivation and Context

Enables BPI to act on messages coming via different messaging providers.

## How Has This Been Tested

Manual testing by triggering NATS messages as explained in the readme
Wrote a bunch of unit tests related to the raw message validation logic.


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
