### PR TITLE
Feature/631 send nats message on create bpi message

### DIFF
--- a/examples/bri-3/README.md
+++ b/examples/bri-3/README.md
@@ -86,7 +86,7 @@ Run the following commands in the terminal:
 $ nats context add local --description "Localhost" # adds localhost server to nats cli
 
 $ nats pub general "<message>" # publishes new message on the general subject
-# Example message format: "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}"
+# Example message format: "{ \"id\": \"0a3dd67c-c031-4b50-95df-0bc5fc1c78b5\", \"fromBpiSubjectId\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\", \"toBpiSubjectId\": \"76cdd901-d87d-4c87-b572-155afe45c128\", \"content\": { \"testProp\":\"testValue\" }, \"signature\": \"xyz\", \"type\": 0}"
 
 ```
 Observe the log messages in the terminal where the app is running.

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -23,7 +23,7 @@ export class BpiMessageAgent {
 
     if (!fromBpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    };
+    }
 
     const toBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       toBpiSubjectId,
@@ -31,7 +31,22 @@ export class BpiMessageAgent {
 
     if (!toBpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    };
+    }
+
+    return [fromBpiSubject, toBpiSubject];
+  }
+
+  public async getFromAndToSubjects(
+    fromBpiSubjectId: string,
+    toBpiSubjectId: string,
+  ): Promise<[BpiSubject, BpiSubject]> {
+    const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
+      fromBpiSubjectId,
+    );
+
+    const toBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
+      toBpiSubjectId,
+    );
 
     return [fromBpiSubject, toBpiSubject];
   }

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -31,7 +31,7 @@ export class BpiMessageAgent {
       await this.bpiMessageStorageAgent.getBpiMessageById(messageId);
 
     if (existingBpiMessage) {
-      throw new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS);
+      throw new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS(messageId));
     }
 
     const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -43,7 +43,6 @@ export class BpiMessageAgent {
     const bpiMessageToUpdate: BpiMessage =
       await this.bpiMessageStorageAgent.getBpiMessageById(id);
 
-    // TODO: throw should not happen in the storage agent
     if (!bpiMessageToUpdate) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
     }

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -1,8 +1,15 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { LoggingService } from '../../../shared/logging/logging.service';
 import { BpiSubjectStorageAgent } from '../../identity/bpiSubjects/agents/bpiSubjectsStorage.agent';
 import { BpiSubject } from '../../identity/bpiSubjects/models/bpiSubject';
-import { NOT_FOUND_ERR_MESSAGE } from '../api/err.messages';
+import {
+  BPI_MESSAGE_ALREADY_EXISTS,
+  NOT_FOUND_ERR_MESSAGE,
+} from '../api/err.messages';
 import { BpiMessage } from '../models/bpiMessage';
 import { BpiMessageType } from '../models/bpiMessageType.enum';
 import { BpiMessageStorageAgent } from './bpiMessagesStorage.agent';
@@ -15,10 +22,18 @@ export class BpiMessageAgent {
     private readonly logger: LoggingService,
   ) {}
 
-  public async getFromAndToSubjectsAndThrowIfNotExist(
+  public async validateNewBpiMessageAgainstExistingBpiEntitiesWithThrow(
+    messageId: string,
     fromBpiSubjectId: string,
     toBpiSubjectId: string,
   ): Promise<[BpiSubject, BpiSubject]> {
+    const existingBpiMessage =
+      await this.bpiMessageStorageAgent.getBpiMessageById(messageId);
+
+    if (existingBpiMessage) {
+      throw new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS);
+    }
+
     const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       fromBpiSubjectId,
     );

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -63,7 +63,7 @@ export class BpiMessageAgent {
 
     if (existingBpiMessage) {
       this.logger.logError(
-        `ProcessInboundMessageCommandHandler: BPI Message with id: ${existingBpiMessage.id} already exists.`,
+        `BpiMessageAgent: BPI Message with id: ${existingBpiMessage.id} already exists.`,
       );
 
       return [false, null, null];
@@ -75,7 +75,7 @@ export class BpiMessageAgent {
 
     if (!fromBpiSubject) {
       this.logger.logError(
-        `ProcessInboundMessageCommandHandler: From Bpi Subjects do not exist.`,
+        `BpiMessageAgent: From Bpi Subjects do not exist.`,
       );
 
       return [false, null, null];
@@ -87,7 +87,7 @@ export class BpiMessageAgent {
 
     if (!fromBpiSubject) {
       this.logger.logError(
-        `ProcessInboundMessageCommandHandler: To Bpi Subject do not exist.`,
+        `BpiMessageAgent: To Bpi Subject do not exist.`,
       );
 
       return [false, null, null];

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -45,11 +45,7 @@ export class BpiMessageAgent {
     return bpiSubject;
   }
 
-  public async validateNewBpiMessageAgainstExistingBpiEntities(
-    messageId: string,
-    fromBpiSubjectId: string,
-    toBpiSubjectId: string,
-  ): Promise<[boolean, BpiSubject, BpiSubject]> {
+  public async bpiMessageIdAlreadyExists(messageId: string): Promise<boolean> {
     const existingBpiMessage =
       await this.bpiMessageStorageAgent.getBpiMessageById(messageId);
 
@@ -58,30 +54,35 @@ export class BpiMessageAgent {
         `BpiMessageAgent: BPI Message with id: ${existingBpiMessage.id} already exists.`,
       );
 
-      return [false, null, null];
+      return true;
     }
 
+    return false;
+  }
+
+  public async fetchFromAndToBpiSubjects(
+    fromBpiSubjectId: string,
+    toBpiSubjectId: string,
+  ): Promise<[BpiSubject, BpiSubject]> {
     const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       fromBpiSubjectId,
     );
 
     if (!fromBpiSubject) {
       this.logger.logError(`BpiMessageAgent: From Bpi Subjects do not exist.`);
-
-      return [false, null, null];
+      return [null, null];
     }
 
     const toBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       toBpiSubjectId,
     );
 
-    if (!fromBpiSubject) {
+    if (!toBpiSubject) {
       this.logger.logError(`BpiMessageAgent: To Bpi Subject do not exist.`);
-
-      return [false, null, null];
+      return [null, null];
     }
 
-    return [true, fromBpiSubject, toBpiSubject];
+    return [fromBpiSubject, toBpiSubject];
   }
 
   public createNewBpiMessage(

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -22,35 +22,27 @@ export class BpiMessageAgent {
     private readonly logger: LoggingService,
   ) {}
 
-  public async validateNewBpiMessageAgainstExistingBpiEntitiesWithThrow(
-    messageId: string,
-    fromBpiSubjectId: string,
-    toBpiSubjectId: string,
-  ): Promise<[BpiSubject, BpiSubject]> {
+  public async throwIfBpiMessageIdExists(messageId: string) {
     const existingBpiMessage =
       await this.bpiMessageStorageAgent.getBpiMessageById(messageId);
 
     if (existingBpiMessage) {
       throw new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS(messageId));
     }
+  }
 
-    const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
-      fromBpiSubjectId,
+  public async fetchBpiSubjectAndThrowIfNotExists(
+    bpiSubjectId: string,
+  ): Promise<BpiSubject> {
+    const bpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
+      bpiSubjectId,
     );
 
-    if (!fromBpiSubject) {
+    if (!bpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
     }
 
-    const toBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
-      toBpiSubjectId,
-    );
-
-    if (!toBpiSubject) {
-      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    }
-
-    return [fromBpiSubject, toBpiSubject];
+    return bpiSubject;
   }
 
   public async validateNewBpiMessageAgainstExistingBpiEntities(

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -74,9 +74,7 @@ export class BpiMessageAgent {
     );
 
     if (!fromBpiSubject) {
-      this.logger.logError(
-        `BpiMessageAgent: From Bpi Subjects do not exist.`,
-      );
+      this.logger.logError(`BpiMessageAgent: From Bpi Subjects do not exist.`);
 
       return [false, null, null];
     }
@@ -86,9 +84,7 @@ export class BpiMessageAgent {
     );
 
     if (!fromBpiSubject) {
-      this.logger.logError(
-        `BpiMessageAgent: To Bpi Subject do not exist.`,
-      );
+      this.logger.logError(`BpiMessageAgent: To Bpi Subject do not exist.`);
 
       return [false, null, null];
     }

--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -20,9 +20,19 @@ export class BpiMessageAgent {
     const fromBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       fromBpiSubjectId,
     );
+
+    if (!fromBpiSubject) {
+      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+    };
+
     const toBpiSubject = await this.bpiSubjectStorageAgent.getBpiSubjectById(
       toBpiSubjectId,
     );
+
+    if (!toBpiSubject) {
+      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+    };
+
     return [fromBpiSubject, toBpiSubject];
   }
 

--- a/examples/bri-3/src/bri/communication/agents/bpiMessagesStorage.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessagesStorage.agent.ts
@@ -1,8 +1,7 @@
 import { Mapper } from '@automapper/core';
 import { InjectMapper } from '@automapper/nestjs';
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../../prisma/prisma.service';
-import { NOT_FOUND_ERR_MESSAGE } from '../api/err.messages';
 import { BpiMessage } from '../models/bpiMessage';
 
 @Injectable()
@@ -18,7 +17,7 @@ export class BpiMessageStorageAgent extends PrismaService {
     });
 
     if (!bpiMessageModel) {
-      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+      return null;
     }
 
     return this.mapper.map(bpiMessageModel, BpiMessage, BpiMessage);

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -3,7 +3,7 @@ import { MessagingAgent } from './messaging.agent';
 let messagingAgent: MessagingAgent;
 
 beforeAll(async () => {
-  messagingAgent = new MessagingAgent(null, null, null);
+  messagingAgent = new MessagingAgent(null, null, null, null);
 });
 
 describe('Messaging Agent', () => {

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -13,7 +13,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [resultDto, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(resultDto).toBeUndefined();
@@ -30,7 +30,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
@@ -44,7 +44,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
@@ -58,7 +58,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
@@ -72,7 +72,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
@@ -86,7 +86,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
@@ -100,7 +100,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(1);
@@ -114,7 +114,7 @@ describe('Messaging Agent', () => {
 
     // Act
     const [resultDto, validationErrors] =
-      messagingAgent.validateBpiMessageFormat(rawMessage);
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
 
     // Assert
     expect(validationErrors.length).toBe(0);

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -26,7 +26,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with invalid UUID in id field', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "pakakoto", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
+      '{ "id": "pakakoto", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const [, validationErrors] =
@@ -40,7 +40,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with invalid UUID in from field', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "7123", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "7123", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const [, validationErrors] =
@@ -54,7 +54,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with invalid UUID in to field', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "msm24", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "msm24", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const [, validationErrors] =
@@ -68,7 +68,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with content field not valid JSON', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": 123, "signature": "xyz", "type": 0}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": 123, "signature": "xyz", "type": 0}';
 
     // Act
     const [, validationErrors] =
@@ -82,7 +82,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with signature field empty', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "", "type": 0}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "", "type": 0}';
 
     // Act
     const [, validationErrors] =
@@ -96,7 +96,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with message type not being info', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
 
     // Act
     const [, validationErrors] =
@@ -110,7 +110,7 @@ describe('Messaging Agent', () => {
   it('Should return no errors and create message dto when validating correct JSON raw message', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "from": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "to": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
 
     // Act
     const [resultDto, validationErrors] =
@@ -120,8 +120,12 @@ describe('Messaging Agent', () => {
     expect(validationErrors.length).toBe(0);
     expect(resultDto).toBeDefined();
     expect(resultDto.id).toEqual('0a3dd67c-c031-4b50-95df-0bc5fc1c78b5');
-    expect(resultDto.from).toEqual('71302cec-0a38-469a-a4e5-f58bdfc4ab32');
-    expect(resultDto.to).toEqual('76cdd901-d87d-4c87-b572-155afe45c128');
+    expect(resultDto.fromBpiSubjectId).toEqual(
+      '71302cec-0a38-469a-a4e5-f58bdfc4ab32',
+    );
+    expect(resultDto.toBpiSubjectId).toEqual(
+      '76cdd901-d87d-4c87-b572-155afe45c128',
+    );
     expect(resultDto.content).toEqual({ testProp: 'testValue' });
     expect(resultDto.signature).toEqual('xyz');
     expect(resultDto.type).toEqual(0);

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -114,7 +114,11 @@ export class MessagingAgent implements OnApplicationBootstrap {
   }
 
   public serializeBpiMessage(bpiMessage: BpiMessage): string {
-    const bpiMessageDto = this.mapper.map(bpiMessage, BpiMessage, BpiMessageDto);
+    const bpiMessageDto = this.mapper.map(
+      bpiMessage,
+      BpiMessage,
+      BpiMessageDto,
+    );
     return JSON.stringify(bpiMessageDto);
   }
 

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -1,8 +1,11 @@
+import { Mapper } from '@automapper/core';
+import { InjectMapper } from '@automapper/nestjs';
 import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
 import { validate } from 'uuid';
 import { LoggingService } from '../../../shared/logging/logging.service';
 import { CreateBpiMessageDto } from '../api/dtos/request/createBpiMessage.dto';
+import { BpiMessageDto } from '../api/dtos/response/bpiMessage.dto';
 import { ProcessInboundBpiMessageCommand } from '../capabilities/processInboundMessage/processInboundMessage.command';
 import { IMessagingClient } from '../messagingClients/messagingClient.interface';
 import { BpiMessage } from '../models/bpiMessage';
@@ -14,6 +17,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     @Inject('IMessagingClient')
     private readonly messagingClient: IMessagingClient,
     private readonly commandBus: CommandBus,
+    @InjectMapper() private mapper: Mapper,
     private readonly logger: LoggingService,
   ) {}
 
@@ -110,7 +114,8 @@ export class MessagingAgent implements OnApplicationBootstrap {
   }
 
   public serializeBpiMessage(bpiMessage: BpiMessage): string {
-    return JSON.stringify(bpiMessage);
+    const bpiMessageDto = this.mapper.map(bpiMessage, BpiMessage, BpiMessageDto);
+    return JSON.stringify(bpiMessageDto);
   }
 
   private parseJsonOrThrow(jsonString: string) {

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -62,7 +62,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
     rawMessage: string,
   ): [CreateBpiMessageDto, string[]] {
     const errors: string[] = [];
-    let newBpiMessageCandidate: CreateBpiMessageDto; // Switch to BpiMessage instead of DTO
+    let newBpiMessageCandidate: CreateBpiMessageDto; // TODO: Switch to BpiMessage instead of DTO
 
     try {
       newBpiMessageCandidate = this.parseJsonOrThrow(rawMessage);

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -24,7 +24,10 @@ export class MessagingAgent implements OnApplicationBootstrap {
     );
   }
 
-  public async publishMessage(channelName: string, message: string): Promise<void> {
+  public async publishMessage(
+    channelName: string,
+    message: string,
+  ): Promise<void> {
     await this.messagingClient.publish(channelName, message);
   }
 

--- a/examples/bri-3/src/bri/communication/agents/mockBpiMessagesStorage.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/mockBpiMessagesStorage.agent.ts
@@ -9,7 +9,7 @@ export class MockBpiMessageStorageAgent {
   async getBpiMessageById(id: string): Promise<BpiMessage> {
     const bpiMessage = this.bpiMessagesStore.find((bp) => bp.id === id);
     if (!bpiMessage) {
-      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+      return null;
     }
     return bpiMessage;
   }

--- a/examples/bri-3/src/bri/communication/agents/mockBpiMessagesStorage.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/mockBpiMessagesStorage.agent.ts
@@ -1,5 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { NOT_FOUND_ERR_MESSAGE } from '../api/err.messages';
+import { Injectable } from '@nestjs/common';
 import { BpiMessage } from '../models/bpiMessage';
 
 @Injectable()

--- a/examples/bri-3/src/bri/communication/api/err.messages.ts
+++ b/examples/bri-3/src/bri/communication/api/err.messages.ts
@@ -1,4 +1,4 @@
 export const NOT_FOUND_ERR_MESSAGE = 'Bpi Message does not exist.';
 export const ID_EMPTY_ERR_MESSAGE = 'Id cannot be empty.';
-export const BPI_MESSAGE_ALREADY_EXISTS =
-  'Bpi Message with this Id already exists.';
+export const BPI_MESSAGE_ALREADY_EXISTS = (id: string) =>
+  `Bpi Message with this Id: ${id} already exists.`;

--- a/examples/bri-3/src/bri/communication/api/err.messages.ts
+++ b/examples/bri-3/src/bri/communication/api/err.messages.ts
@@ -1,2 +1,4 @@
 export const NOT_FOUND_ERR_MESSAGE = 'Bpi Message does not exist.';
 export const ID_EMPTY_ERR_MESSAGE = 'Id cannot be empty.';
+export const BPI_MESSAGE_ALREADY_EXISTS =
+  'Bpi Message with this Id already exists.';

--- a/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
+++ b/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
@@ -148,7 +148,9 @@ describe('MessageController', () => {
       // Act and assert
       expect(async () => {
         await mController.createBpiMessage(requestDto);
-      }).rejects.toThrow(new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS));
+      }).rejects.toThrow(
+        new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS(requestDto.id)),
+      );
     });
 
     it('should throw BadRequest non existent bpi subject id provided in from field', () => {

--- a/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
+++ b/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
@@ -137,7 +137,7 @@ describe('MessageController', () => {
     it('should throw BadRequest if existing bpi message id provided in id field', () => {
       // Arrange
       const requestDto = {
-        id: 'f3e4295d-6a2a-4f04-8477-02f781eb93f8',
+        id: existingBpiMessage1.id,
         from: existingBpiSubject1.id,
         to: existingBpiSubject2.id,
         content: 'hello world',

--- a/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
+++ b/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
@@ -35,7 +35,7 @@ describe('MessageController', () => {
   let mockBpiSubjectStorageAgent: MockBpiSubjectStorageAgent;
   let existingBpiSubject1: BpiSubject;
   let existingBpiSubject2: BpiSubject;
-  let existingBpiMessage1: BpiMessage;
+  let existingBpiMessage: BpiMessage;
 
   beforeEach(async () => {
     mockBpiMessageStorageAgent = new MockBpiMessageStorageAgent();
@@ -47,7 +47,7 @@ describe('MessageController', () => {
       new BpiSubject('', 'name2', 'desc2', 'xyz2', []),
     );
 
-    existingBpiMessage1 = await mockBpiMessageStorageAgent.storeNewBpiMessage(
+    existingBpiMessage = await mockBpiMessageStorageAgent.storeNewBpiMessage(
       new BpiMessage(
         'f3e4295d-6a2a-4f04-8477-02f781eb93f8',
         existingBpiSubject1,
@@ -137,7 +137,7 @@ describe('MessageController', () => {
     it('should throw BadRequest if existing bpi message id provided in id field', () => {
       // Arrange
       const requestDto = {
-        id: existingBpiMessage1.id,
+        id: existingBpiMessage.id,
         from: existingBpiSubject1.id,
         to: existingBpiSubject2.id,
         content: 'hello world',

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -15,6 +15,8 @@ export class CreateBpiMessageCommandHandler
   ) {}
 
   async execute(command: CreateBpiMessageCommand) {
+    // TODO: Validate Bpi Message Id unique
+
     const [fromBpiSubject, toBpiSubject] =
       await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
         command.from,

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -15,12 +15,15 @@ export class CreateBpiMessageCommandHandler
   ) {}
 
   async execute(command: CreateBpiMessageCommand) {
-    const [fromBpiSubject, toBpiSubject] =
-      await this.agent.validateNewBpiMessageAgainstExistingBpiEntitiesWithThrow(
-        command.id,
-        command.from,
-        command.to,
-      );
+    await this.agent.throwIfBpiMessageIdExists(command.id);
+
+    const fromBpiSubject = await this.agent.fetchBpiSubjectAndThrowIfNotExists(
+      command.from,
+    );
+
+    const toBpiSubject = await this.agent.fetchBpiSubjectAndThrowIfNotExists(
+      command.to,
+    );
 
     // TODO: #649 - Validate the signature and the pk of the sender
 

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -1,7 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { BpiMessageAgent } from '../../agents/bpiMessages.agent';
 import { BpiMessageStorageAgent } from '../../agents/bpiMessagesStorage.agent';
 import { MessagingAgent } from '../../agents/messaging.agent';
+import { BPI_MESSAGE_ALREADY_EXISTS } from '../../api/err.messages';
 import { CreateBpiMessageCommand } from './createBpiMessage.command';
 
 @CommandHandler(CreateBpiMessageCommand)
@@ -15,7 +17,13 @@ export class CreateBpiMessageCommandHandler
   ) {}
 
   async execute(command: CreateBpiMessageCommand) {
-    // TODO: Validate Bpi Message Id unique
+    const existingBpiMessage = await this.storageAgent.getBpiMessageById(
+      command.id,
+    );
+
+    if (existingBpiMessage) {
+      throw new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS);
+    }
 
     const [fromBpiSubject, toBpiSubject] =
       await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
@@ -39,7 +47,7 @@ export class CreateBpiMessageCommandHandler
     );
 
     // TODO: This is naive as it publishes to a channel anyone who can auth with the NATS server can subscribe to.
-    // Wiil be improved by introducing NATS authz to allow only the recipient Bpi Subject to listen on this channel
+    // Will be improved by introducing NATS authz to allow only the recipient Bpi Subject to listen on this channel (#648)
     await this.messagingAgent.publishMessage(
       toBpiSubject.publicKey,
       this.messagingAgent.serializeBpiMessage(newBpiMessage),

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -1,9 +1,7 @@
-import { BadRequestException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { BpiMessageAgent } from '../../agents/bpiMessages.agent';
 import { BpiMessageStorageAgent } from '../../agents/bpiMessagesStorage.agent';
 import { MessagingAgent } from '../../agents/messaging.agent';
-import { BPI_MESSAGE_ALREADY_EXISTS } from '../../api/err.messages';
 import { CreateBpiMessageCommand } from './createBpiMessage.command';
 
 @CommandHandler(CreateBpiMessageCommand)
@@ -17,16 +15,9 @@ export class CreateBpiMessageCommandHandler
   ) {}
 
   async execute(command: CreateBpiMessageCommand) {
-    const existingBpiMessage = await this.storageAgent.getBpiMessageById(
-      command.id,
-    );
-
-    if (existingBpiMessage) {
-      throw new BadRequestException(BPI_MESSAGE_ALREADY_EXISTS);
-    }
-
     const [fromBpiSubject, toBpiSubject] =
-      await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
+      await this.agent.validateNewBpiMessageAgainstExistingBpiEntitiesWithThrow(
+        command.id,
         command.from,
         command.to,
       );

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -31,7 +31,7 @@ export class CreateBpiMessageCommandHandler
         command.to,
       );
 
-    // TODO: Validate the signature and the pk of the sender
+    // TODO: #649 - Validate the signature and the pk of the sender
 
     const newBpiMessageCandidate = this.agent.createNewBpiMessage(
       command.id,

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -40,7 +40,8 @@ export class CreateBpiMessageCommandHandler
     // Wiil be improved by introducing NATS authz to allow only the recipient Bpi Subject to listen on this channel
     await this.messagingAgent.publishMessage(
       toBpiSubject.publicKey,
-      this.messagingAgent.serializeBpiMessage(newBpiMessage));
+      this.messagingAgent.serializeBpiMessage(newBpiMessage),
+    );
 
     return newBpiMessage.id;
   }

--- a/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/createBpiMessage/createBpiMessageCommand.handler.ts
@@ -21,6 +21,8 @@ export class CreateBpiMessageCommandHandler
         command.to,
       );
 
+    // TODO: Validate the signature and the pk of the sender
+
     const newBpiMessageCandidate = this.agent.createNewBpiMessage(
       command.id,
       fromBpiSubject,
@@ -33,6 +35,12 @@ export class CreateBpiMessageCommandHandler
     const newBpiMessage = await this.storageAgent.storeNewBpiMessage(
       newBpiMessageCandidate,
     );
+
+    // TODO: This is naive as it publishes to a channel anyone who can auth with the NATS server can subscribe to.
+    // Wiil be improved by introducing NATS authz to allow only the recipient Bpi Subject to listen on this channel
+    await this.messagingAgent.publishMessage(
+      toBpiSubject.publicKey,
+      this.messagingAgent.serializeBpiMessage(newBpiMessage));
 
     return newBpiMessage.id;
   }

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -18,14 +18,14 @@ export class ProcessInboundMessageCommandHandler
   ) {}
 
   async execute(command: ProcessInboundBpiMessageCommand) {
-    const [isValid, fromBpiSubject, toBpiSubject] =
-      await this.agent.validateNewBpiMessageAgainstExistingBpiEntities(
-        command.id,
-        command.from,
-        command.to,
-      );
+    if (this.agent.bpiMessageIdAlreadyExists(command.id)) {
+      return;
+    }
 
-    if (!isValid) {
+    const [fromBpiSubject, toBpiSubject] =
+      await this.agent.fetchFromAndToBpiSubjects(command.from, command.to);
+
+    if (!fromBpiSubject || !toBpiSubject) {
       return;
     }
 

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -22,7 +22,7 @@ export class ProcessInboundMessageCommandHandler
 
   async execute(command: ProcessInboundBpiMessageCommand) {
     // TODO: Validate Bpi Message Id unique
-    
+
     let fromBpiSubject: BpiSubject;
     let toBpiSubject: BpiSubject;
 

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -41,7 +41,7 @@ export class ProcessInboundMessageCommandHandler
       return;
     }
 
-    // TODO: Validate the signature and the pk of the sender
+    // TODO: #649 - Validate the signature and the pk of the sender
 
     const newBpiMessageCandidate = this.agent.createNewBpiMessage(
       command.id,

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -21,6 +21,8 @@ export class ProcessInboundMessageCommandHandler
   ) {}
 
   async execute(command: ProcessInboundBpiMessageCommand) {
+    // TODO: Validate Bpi Message Id unique
+    
     let fromBpiSubject: BpiSubject;
     let toBpiSubject: BpiSubject;
 

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -8,6 +8,7 @@ import { ProcessInboundBpiMessageCommand } from './processInboundMessage.command
 
 // Difference between this and the create bpi message command handler is that this one does not
 // want to stop the execution flow by throwing a nestjs exception (which results in 404 response in the other handler)
+// TODO: Consider using a NestJs Saga or another command dispatch to avoid code duplication
 @CommandHandler(ProcessInboundBpiMessageCommand)
 export class ProcessInboundMessageCommandHandler
   implements ICommandHandler<ProcessInboundBpiMessageCommand>

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -21,7 +21,16 @@ export class ProcessInboundMessageCommandHandler
   ) {}
 
   async execute(command: ProcessInboundBpiMessageCommand) {
-    // TODO: Validate Bpi Message Id unique
+    const existingBpiMessage = await this.storageAgent.getBpiMessageById(
+      command.id,
+    );
+
+    if (existingBpiMessage) {
+      this.logger.logError(
+        `ProcessInboundMessageCommandHandler: BPI Message with id: ${existingBpiMessage.id} already exists.`,
+      );
+      return;
+    }
 
     let fromBpiSubject: BpiSubject;
     let toBpiSubject: BpiSubject;

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -24,7 +24,7 @@ export class ProcessInboundMessageCommandHandler
     let toBpiSubject: BpiSubject;
 
     // TODO: Use an agent method that does not throw in case of invalid from and to
-    // but instead returns false 
+    // but instead returns false
     try {
       [fromBpiSubject, toBpiSubject] =
         await this.agent.getFromAndToSubjectsAndThrowIfNotExist(
@@ -49,13 +49,15 @@ export class ProcessInboundMessageCommandHandler
       command.type,
     );
 
-    const newBpiMessage = await this.storageAgent.storeNewBpiMessage(newBpiMessageCandidate);
+    const newBpiMessage = await this.storageAgent.storeNewBpiMessage(
+      newBpiMessageCandidate,
+    );
 
     // TODO: This is naive as it publishes to a channel anyone who can auth with the NATS server can subscribe to.
     // Wiil be improved by introducing NATS authz to allow only the recipient Bpi Subject to listen on this channel
     await this.messagingAgent.publishMessage(
       toBpiSubject.publicKey,
-      this.messagingAgent.serializeBpiMessage(newBpiMessage));
-
+      this.messagingAgent.serializeBpiMessage(newBpiMessage),
+    );
   }
 }

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
@@ -38,9 +38,19 @@ export class BpiSubjectAccountAgent {
     const creatorBpiSubject = await this.subjectStorageAgent.getBpiSubjectById(
       creatorBpiSubjectId,
     );
+
+    if (!creatorBpiSubject) {
+      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+    };
+
     const ownerBpiSubject = await this.subjectStorageAgent.getBpiSubjectById(
       ownerBpiSubjectId,
     );
+
+    if (!ownerBpiSubject) {
+      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+    };
+
     return {
       creatorBpiSubject,
       ownerBpiSubject,

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
@@ -41,7 +41,7 @@ export class BpiSubjectAccountAgent {
 
     if (!creatorBpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    };
+    }
 
     const ownerBpiSubject = await this.subjectStorageAgent.getBpiSubjectById(
       ownerBpiSubjectId,
@@ -49,7 +49,7 @@ export class BpiSubjectAccountAgent {
 
     if (!ownerBpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    };
+    }
 
     return {
       creatorBpiSubject,

--- a/examples/bri-3/src/bri/identity/bpiSubjects/agents/bpiSubjectsStorage.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/agents/bpiSubjectsStorage.agent.ts
@@ -21,8 +21,9 @@ export class BpiSubjectStorageAgent extends PrismaService {
     });
 
     if (!bpiSubjectModel) {
-      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    }
+      return null;
+    };
+
     return this.mapper.map(bpiSubjectModel, BpiSubject, BpiSubject);
   }
 

--- a/examples/bri-3/src/bri/identity/bpiSubjects/agents/bpiSubjectsStorage.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/agents/bpiSubjectsStorage.agent.ts
@@ -22,7 +22,7 @@ export class BpiSubjectStorageAgent extends PrismaService {
 
     if (!bpiSubjectModel) {
       return null;
-    };
+    }
 
     return this.mapper.map(bpiSubjectModel, BpiSubject, BpiSubject);
   }

--- a/examples/bri-3/src/bri/identity/bpiSubjects/capabilities/getBpiSubjectById/getBpiSubjectByIdQuery.handler.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/capabilities/getBpiSubjectById/getBpiSubjectByIdQuery.handler.ts
@@ -19,9 +19,10 @@ export class GetBpiSubjectByIdQueryHandler
 
   async execute(query: GetBpiSubjectByIdQuery) {
     const bpiSubject = await this.storageAgent.getBpiSubjectById(query.id);
+
     if (!bpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    }
+    };
 
     return this.autoMapper.map(bpiSubject, BpiSubject, BpiSubjectDto);
   }

--- a/examples/bri-3/src/bri/identity/bpiSubjects/capabilities/getBpiSubjectById/getBpiSubjectByIdQuery.handler.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/capabilities/getBpiSubjectById/getBpiSubjectByIdQuery.handler.ts
@@ -22,7 +22,7 @@ export class GetBpiSubjectByIdQueryHandler
 
     if (!bpiSubject) {
       throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
-    };
+    }
 
     return this.autoMapper.map(bpiSubject, BpiSubject, BpiSubjectDto);
   }

--- a/examples/bri-3/test/bri.postman_collection.json
+++ b/examples/bri-3/test/bri.postman_collection.json
@@ -1007,7 +1007,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"id\": \"123\",\n  \"from\": \"eb6ab5d2-fe0e-4c74-b6e2-343f16eface4\",\n  \"to\": \"cf77044d-dd3c-42b6-98dc-5d15ef769eb8\",\n  \"content\": \"hello world\",\n  \"signature\": \"xyz\",\n  \"type\": 1\n}",
+							"raw": "{\n  \"id\": \"1d1242dd-47e5-4ae8-8e7e-158540309d12\",\n  \"from\": \"71302cec-0a38-469a-a4e5-f58bdfc4ab32\",\n  \"to\": \"76cdd901-d87d-4c87-b572-155afe45c128\",\n  \"content\": \"hello world\",\n  \"signature\": \"xyz\",\n  \"type\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
# Description

This PR introduces sending of BPI Message to recipient via NATS after successful creation via REST or NATS.

## Related Issue

#631

## Motivation and Context

Enables communication between Bpi Subjects via the BPI NATS server instance

## How Has This Been Tested

Manual testing performed by following the instructions from the readme file. Unit tests for part of the logic.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
