### PR TITLE
Issue #651 - Add Ryan to codeowners, update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @skarred14 @ognjenkurtic @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern @ybittan @fleischr
+*       @skarred14 @ognjenkurtic @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern @ybittan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # the repo. Unless a later match takes precedence,
 # the following owers will be requested for
 # review when someone opens a pull request.
-*       @skarred14 @ognjenkurtic @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern @ybittan
+*       @skarred14 @ognjenkurtic @therecanbeonlyone1969 @fosgate29 @Manik-Jain @skosito @Kasshern @ybittan @fleischr

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,13 +18,7 @@ They can/should also contribute in the following ways:
 
 Code and Systems maintainers
 
-- [Sam Stokes](https://github.com/bitwiseguy)
-- [Kartheek Solipuram](https://github.com/skarred14)
-- [Kyle Thomas](https://github.com/kthomas)
-- [Tomasz Stanczak](https://github.com/tkstanczak)
-- [Lucas Rodriguez Benitez](https://github.com/LucasRodriguez)
-- [Anais Ofranc](https://github.com/Consianimis)
-- [Hamza Tokuchi](https://github.com/Meuko) - [BlockLab](https://www.blocklab.nl/)
+Please see the [CODEOWNERS file](./.github/CODEOWNERS) in this repo for the most up to date list of Baseline maintainers
 
 # How to become a maintainer?
 


### PR DESCRIPTION

# Description

Adds Ryan as a Baseline codeowner
Adds a link to the codeowners file in the MAINTAINERS doc

## Related Issue

#651 

## Motivation and Context

Ryan to help out with BRI-1 specific topics and cleanup in Baseline repo
Current maintainers file uses an out of date list of maintainers

## How Has This Been Tested

non-breaking change
## Screenshots (if appropriate)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Request to be added as a Code Owner/Maintainer

## Checklist

- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ X] I commit to abide by the Responsibilities of Code Owners/Maintainers.
