### PR TITLE
Feature/634 abilities decorator

### DIFF
--- a/examples/bri-3/src/app.module.ts
+++ b/examples/bri-3/src/app.module.ts
@@ -12,6 +12,8 @@ import { AuthModule } from './bri/auth/auth.module';
 import { APP_GUARD } from '@nestjs/core';
 import { DidJwtAuthGuard } from './bri/auth/guards/didJwt.guard';
 import { SubjectModule } from './bri/identity/bpiSubjects/subjects.module';
+import { AuthzGuard } from './bri/authz/guards/authz.guard';
+import { AuthzModule } from './bri/authz/authz.module';
 
 @Module({
   imports: [
@@ -25,6 +27,7 @@ import { SubjectModule } from './bri/identity/bpiSubjects/subjects.module';
       strategyInitializer: classes(),
     }),
     AuthModule,
+    AuthzModule,
     SubjectModule,
   ],
   providers: [
@@ -32,6 +35,10 @@ import { SubjectModule } from './bri/identity/bpiSubjects/subjects.module';
     {
       provide: APP_GUARD,
       useClass: DidJwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: AuthzGuard,
     },
   ],
 })

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -34,8 +34,8 @@ const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
 };
 
 @Injectable()
-export class AbilityFactory {
-  defineAbilityFor(bpiSubject: BpiSubject): AppAbility {
+export class AuthzFactory {
+  buildAuthzFor(bpiSubject: BpiSubject): AppAbility {
     const builder = new AbilityBuilder(PureAbility as AbilityClass<AppAbility>);
     // this is just for start, once there are more roles, this should be modified a bit
     const role = bpiSubject.roles[0]?.name;

--- a/examples/bri-3/src/bri/authz/authz.module.ts
+++ b/examples/bri-3/src/bri/authz/authz.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
-import { AbilityFactory } from './ability.factory';
+import { AuthzFactory } from './authz.factory';
 
 @Module({
-  providers: [AbilityFactory],
-  exports: [AbilityFactory],
+  providers: [AuthzFactory],
+  exports: [AuthzFactory],
 })
 export class AuthzModule {}

--- a/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const CHECK_AUTHZ = 'check_authz';
+
+export interface IRequirement {
+  action: any;
+  subject: any;
+}
+
+export const CheckAuthz = (...requirements: IRequirement[]) =>
+  SetMetadata(CHECK_AUTHZ, requirements);

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -6,14 +6,14 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { AbilityFactory } from '../ability.factory';
+import { AuthzFactory } from '../authz.factory';
 import { CHECK_AUTHZ, IRequirement } from './authz.decorator';
 
 @Injectable()
 export class AuthzGuard implements CanActivate {
   constructor(
     private reflector: Reflector,
-    private abilityFactory: AbilityFactory,
+    private authzFactory: AuthzFactory,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -22,11 +22,11 @@ export class AuthzGuard implements CanActivate {
       [];
 
     const req = context.switchToHttp().getRequest();
-    const ability = this.abilityFactory.defineAbilityFor(req.bpiSubject);
+    const authz = this.authzFactory.buildAuthzFor(req.bpiSubject);
 
     try {
       for (const requirement of requirements) {
-        ForbiddenError.from(ability).throwUnlessCan(
+        ForbiddenError.from(authz).throwUnlessCan(
           requirement.action,
           requirement.subject,
         );

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@casl/ability/dist/types/ForbiddenError';
+import { ForbiddenError } from '@casl/ability';
 import {
   CanActivate,
   ExecutionContext,

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -1,0 +1,41 @@
+import { ForbiddenError } from '@casl/ability/dist/types/ForbiddenError';
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AbilityFactory } from '../ability.factory';
+import { CHECK_AUTHZ, IRequirement } from './authz.decorator';
+
+@Injectable()
+export class AuthzGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private abilityFactory: AbilityFactory,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requirements =
+      this.reflector.get<IRequirement[]>(CHECK_AUTHZ, context.getHandler()) ||
+      [];
+
+    const req = context.switchToHttp().getRequest();
+    const ability = this.abilityFactory.defineAbilityFor(req.bpiSubject);
+
+    try {
+      for (const requirement of requirements) {
+        ForbiddenError.from(ability).throwUnlessCan(
+          requirement.action,
+          requirement.subject,
+        );
+      }
+      return true;
+    } catch (err) {
+      if (err instanceof ForbiddenError) {
+        throw new ForbiddenException(err.message);
+      }
+    }
+  }
+}

--- a/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.spec.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.spec.ts
@@ -19,19 +19,9 @@ import { classes } from '@automapper/classes';
 import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 import { AbilityFactory } from '../../../authz/ability.factory';
 import { AuthzModule } from '../../../authz/authz.module';
-import { BpiSubjectRoleName } from '../models/bpiSubjectRole';
 
 describe('SubjectController', () => {
   let sController: SubjectController;
-  const mockReqBpiSubject = {
-    bpiSubject: {
-      roles: [
-        {
-          name: BpiSubjectRoleName.INTERNAL_BPI_SUBJECT,
-        },
-      ],
-    },
-  };
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       imports: [
@@ -74,30 +64,6 @@ describe('SubjectController', () => {
       }).rejects.toThrow(new NotFoundException(NOT_FOUND_ERR_MESSAGE));
     });
 
-    it('external subject should not be able to create new subjects', async () => {
-      // Arange
-      const mockReqBpiSubject = {
-        bpiSubject: {
-          roles: [
-            {
-              name: BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT,
-            },
-          ],
-        },
-      };
-
-      const requestDto = {
-        name: 'name',
-        desc: 'desc',
-        publicKey: 'publicKey',
-      } as CreateBpiSubjectDto;
-
-      // Act and assert
-      expect(async () => {
-        await sController.createBpiSubject(mockReqBpiSubject, requestDto);
-      }).rejects.toThrow('Cannot execute "manage" on "BpiSubject"');
-    });
-
     it('should return the correct bpi subject if proper id passed ', async () => {
       // Arrange
       const requestDto = {
@@ -106,10 +72,7 @@ describe('SubjectController', () => {
         publicKey: 'publicKey',
       } as CreateBpiSubjectDto;
 
-      const newBpiSubjectId = await sController.createBpiSubject(
-        mockReqBpiSubject,
-        requestDto,
-      );
+      const newBpiSubjectId = await sController.createBpiSubject(requestDto);
 
       // Act
       const createdBpiSubject = await sController.getBpiSubjectById(
@@ -140,20 +103,14 @@ describe('SubjectController', () => {
         desc: 'desc1',
         publicKey: 'publicKey1',
       } as CreateBpiSubjectDto;
-      const newBpiSubjectId1 = await sController.createBpiSubject(
-        mockReqBpiSubject,
-        requestDto1,
-      );
+      const newBpiSubjectId1 = await sController.createBpiSubject(requestDto1);
 
       const requestDto2 = {
         name: 'name2',
         desc: 'desc2',
         publicKey: 'publicKey2',
       } as CreateBpiSubjectDto;
-      const newBpiSubjectId2 = await sController.createBpiSubject(
-        mockReqBpiSubject,
-        requestDto2,
-      );
+      const newBpiSubjectId2 = await sController.createBpiSubject(requestDto2);
 
       // Act
       const bpiSubjects = await sController.getAllBpiSubjects();
@@ -181,7 +138,7 @@ describe('SubjectController', () => {
 
       // Act and assert
       expect(async () => {
-        await sController.createBpiSubject(mockReqBpiSubject, requestDto);
+        await sController.createBpiSubject(requestDto);
       }).rejects.toThrow(new BadRequestException(NAME_EMPTY_ERR_MESSAGE));
     });
 
@@ -194,10 +151,7 @@ describe('SubjectController', () => {
       } as CreateBpiSubjectDto;
 
       // Act
-      const response = await sController.createBpiSubject(
-        mockReqBpiSubject,
-        requestDto,
-      );
+      const response = await sController.createBpiSubject(requestDto);
 
       // Assert
       expect(uuidValidate(response));
@@ -229,7 +183,6 @@ describe('SubjectController', () => {
         publicKey: 'publicKey1',
       } as CreateBpiSubjectDto;
       const newBpiSubjectId = await sController.createBpiSubject(
-        mockReqBpiSubject,
         createRequestDto,
       );
       const updateRequestDto = {
@@ -271,7 +224,6 @@ describe('SubjectController', () => {
         publicKey: 'publicKey1',
       } as CreateBpiSubjectDto;
       const newBpiSubjectId = await sController.createBpiSubject(
-        mockReqBpiSubject,
         createRequestDto,
       );
 

--- a/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.spec.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.spec.ts
@@ -17,7 +17,7 @@ import { SubjectsProfile } from '../subjects.profile';
 import { AutomapperModule } from '@automapper/nestjs';
 import { classes } from '@automapper/classes';
 import { validate as uuidValidate, version as uuidVersion } from 'uuid';
-import { AbilityFactory } from '../../../authz/ability.factory';
+import { AuthzFactory } from '../../../authz/authz.factory';
 import { AuthzModule } from '../../../authz/authz.module';
 
 describe('SubjectController', () => {
@@ -41,7 +41,7 @@ describe('SubjectController', () => {
         GetAllBpiSubjectsQueryHandler,
         BpiSubjectStorageAgent,
         SubjectsProfile,
-        AbilityFactory,
+        AuthzFactory,
       ],
     })
       .overrideProvider(BpiSubjectStorageAgent)

--- a/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
@@ -6,10 +6,8 @@ import {
   Param,
   Post,
   Put,
-  UseGuards,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { AbilityFactory } from '../../../authz/ability.factory';
 import { CreateBpiSubjectCommand } from '../capabilities/createBpiSubject/createBpiSubject.command';
 import { DeleteBpiSubjectCommand } from '../capabilities/deleteBpiSubject/deleteBpiSubject.command';
 import { GetAllBpiSubjectsQuery } from '../capabilities/getAllBpiSubjects/getAllBpiSubjects.query';
@@ -19,15 +17,10 @@ import { CreateBpiSubjectDto } from './dtos/request/createBpiSubject.dto';
 import { UpdateBpiSubjectDto } from './dtos/request/updateBpiSubject.dto';
 import { BpiSubjectDto } from './dtos/response/bpiSubject.dto';
 import { CheckAuthz } from '../../../authz/guards/authz.decorator';
-import { AuthzGuard } from 'src/bri/authz/guards/authz.guard';
 
 @Controller('subjects')
 export class SubjectController {
-  constructor(
-    private commandBus: CommandBus,
-    private queryBus: QueryBus,
-    private abilityFactory: AbilityFactory,
-  ) {}
+  constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
 
   @Get('/:id')
   async getBpiSubjectById(@Param('id') id: string): Promise<BpiSubjectDto> {
@@ -41,7 +34,6 @@ export class SubjectController {
 
   @Post()
   @CheckAuthz({ action: 'manage', subject: 'BpiSubject' })
-  @UseGuards(AuthzGuard)
   async createBpiSubject(
     @Body() requestDto: CreateBpiSubjectDto,
   ): Promise<string> {

--- a/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
@@ -19,6 +19,7 @@ import { CreateBpiSubjectDto } from './dtos/request/createBpiSubject.dto';
 import { UpdateBpiSubjectDto } from './dtos/request/updateBpiSubject.dto';
 import { BpiSubjectDto } from './dtos/response/bpiSubject.dto';
 import { ForbiddenError } from '@casl/ability';
+import { CheckAuthz } from '../../../authz/guards/authz.decorator';
 
 @Controller('subjects')
 export class SubjectController {
@@ -39,6 +40,7 @@ export class SubjectController {
   }
 
   @Post()
+  @CheckAuthz({ action: 'manage', subject: 'BpiSubject' })
   async createBpiSubject(
     @Req() req,
     @Body() requestDto: CreateBpiSubjectDto,


### PR DESCRIPTION
# Description

Introduce global authz guard for bri-3. Rename library specific `ability` terminology with `authz` in current related files. 

## Related Issue

https://github.com/eea-oasis/baseline/issues/634

## Motivation and Context

Reduce code duplication for authz.

## How Has This Been Tested

Postman and unit tests.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
