### PR TITLE
Feature/634 casl prisma authz

### DIFF
--- a/examples/bri-3/package-lock.json
+++ b/examples/bri-3/package-lock.json
@@ -13,6 +13,7 @@
         "@automapper/core": "^8.7.6",
         "@automapper/nestjs": "^8.7.6",
         "@casl/ability": "^6.3.3",
+        "@casl/prisma": "^1.3.3",
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/cqrs": "^9.0.1",
@@ -20,10 +21,8 @@
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "@prisma/client": "^4.4.0",
-        "bcrypt": "^5.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
-        "crypto": "^1.0.1",
         "did-jwt": "^6.10.1",
         "did-resolver": "^4.0.1",
         "eslint-config-react-app": "^7.0.1",
@@ -2134,6 +2133,19 @@
         "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
+    "node_modules/@casl/prisma": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@casl/prisma/-/prisma-1.3.3.tgz",
+      "integrity": "sha512-G55pyNsIJlS18lfcf4Gj56g0TSHFF3kh8G6rLuUIac2e+lLzrkSWxSS15+YqPDkkVRr0rynKyCR/60CXNTMnhA==",
+      "dependencies": {
+        "@ucast/core": "^1.10.0",
+        "@ucast/js": "^3.0.1"
+      },
+      "peerDependencies": {
+        "@casl/ability": "^5.3.0 || ^6.0.0",
+        "@prisma/client": "^2.14.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "dev": true,
@@ -3366,24 +3378,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.10",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -4778,10 +4772,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -4829,16 +4819,6 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "license": "MIT"
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
     },
     "node_modules/ajv": {
       "version": "8.11.0",
@@ -4939,33 +4919,6 @@
     "node_modules/append-field": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/aproba": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -5308,22 +5261,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bcrypt": {
-      "version": "5.1.0",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.10",
-        "node-addon-api": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/bcrypt/node_modules/node-addon-api": {
-      "version": "5.0.0",
-      "license": "MIT"
-    },
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -5646,13 +5583,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "dev": true,
@@ -5784,13 +5714,6 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/colors": {
       "version": "1.4.0",
       "license": "MIT",
@@ -5847,10 +5770,6 @@
     "node_modules/consola": {
       "version": "2.15.3",
       "license": "MIT"
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -5987,12 +5906,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6061,10 +5974,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
@@ -6078,13 +5987,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -6211,6 +6113,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -7485,26 +7388,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/fs-monkey": {
       "version": "1.0.3",
       "dev": true,
@@ -7557,24 +7440,6 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -7783,10 +7648,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "license": "ISC"
-    },
     "node_modules/hash-base": {
       "version": "3.1.0",
       "license": "MIT",
@@ -7853,17 +7714,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -8128,6 +7978,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9481,6 +9332,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -9494,6 +9346,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9630,37 +9483,6 @@
       "version": "1.2.6",
       "license": "MIT"
     },
-    "node_modules/minipass": {
-      "version": "4.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "license": "MIT",
@@ -9788,19 +9610,6 @@
       "version": "2.0.6",
       "license": "MIT"
     },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -9818,16 +9627,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/number-to-bn": {
@@ -10967,10 +10766,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "license": "MIT"
@@ -11037,6 +10832,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -11146,6 +10942,7 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -11350,31 +11147,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "6.1.13",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/terminal-link": {
@@ -12174,13 +11946,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/windows-release": {
@@ -13725,6 +13490,15 @@
         "@ucast/mongo2js": "^1.3.0"
       }
     },
+    "@casl/prisma": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@casl/prisma/-/prisma-1.3.3.tgz",
+      "integrity": "sha512-G55pyNsIJlS18lfcf4Gj56g0TSHFF3kh8G6rLuUIac2e+lLzrkSWxSS15+YqPDkkVRr0rynKyCR/60CXNTMnhA==",
+      "requires": {
+        "@ucast/core": "^1.10.0",
+        "@ucast/js": "^3.0.1"
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "dev": true,
@@ -14457,20 +14231,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@mapbox/node-pre-gyp": {
-      "version": "1.0.10",
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
       }
     },
     "@nestjs/cli": {
@@ -15439,9 +15199,6 @@
       "version": "4.2.2",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1"
-    },
     "accepts": {
       "version": "1.3.8",
       "requires": {
@@ -15467,12 +15224,6 @@
     },
     "aes-js": {
       "version": "3.0.0"
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "requires": {
-        "debug": "4"
-      }
     },
     "ajv": {
       "version": "8.11.0",
@@ -15527,26 +15278,6 @@
     },
     "append-field": {
       "version": "1.0.0"
-    },
-    "aproba": {
-      "version": "2.0.0"
-    },
-    "are-we-there-yet": {
-      "version": "2.0.0",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "arg": {
       "version": "4.1.3",
@@ -15794,18 +15525,6 @@
       "version": "1.5.1",
       "dev": true
     },
-    "bcrypt": {
-      "version": "5.1.0",
-      "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.10",
-        "node-addon-api": "^5.0.0"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "5.0.0"
-        }
-      }
-    },
     "bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -16017,9 +15736,6 @@
         "readdirp": "~3.6.0"
       }
     },
-    "chownr": {
-      "version": "2.0.0"
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "dev": true
@@ -16102,9 +15818,6 @@
     "color-name": {
       "version": "1.1.4"
     },
-    "color-support": {
-      "version": "1.1.3"
-    },
     "colors": {
       "version": "1.4.0"
     },
@@ -16142,9 +15855,6 @@
     },
     "consola": {
       "version": "2.15.3"
-    },
-    "console-control-strings": {
-      "version": "1.1.0"
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -16242,11 +15952,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
-    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -16289,17 +15994,11 @@
       "version": "1.0.0",
       "dev": true
     },
-    "delegates": {
-      "version": "1.0.0"
-    },
     "depd": {
       "version": "2.0.0"
     },
     "destroy": {
       "version": "1.2.0"
-    },
-    "detect-libc": {
-      "version": "2.0.1"
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -16395,7 +16094,8 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2"
@@ -17303,20 +17003,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "fs-minipass": {
-      "version": "2.1.0",
-      "requires": {
-        "minipass": "^3.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
-      }
-    },
     "fs-monkey": {
       "version": "1.0.3",
       "dev": true
@@ -17350,20 +17036,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
-    },
-    "gauge": {
-      "version": "3.0.2",
-      "requires": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.2"
@@ -17485,9 +17157,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1"
-    },
     "hash-base": {
       "version": "3.1.0",
       "requires": {
@@ -17537,13 +17206,6 @@
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
       }
     },
     "human-signals": {
@@ -17698,7 +17360,8 @@
       "version": "2.1.1"
     },
     "is-fullwidth-code-point": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -18613,12 +18276,14 @@
     },
     "make-dir": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "dev": true
         }
       }
     },
@@ -18701,27 +18366,6 @@
     },
     "minimist": {
       "version": "1.2.6"
-    },
-    "minipass": {
-      "version": "4.0.0",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "2.1.2",
-      "requires": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
-      }
     },
     "mkdirp": {
       "version": "0.5.6",
@@ -18806,12 +18450,6 @@
     "node-releases": {
       "version": "2.0.6"
     },
-    "nopt": {
-      "version": "5.0.0",
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-path": {
       "version": "3.0.0",
       "dev": true
@@ -18821,15 +18459,6 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
-      }
-    },
-    "npmlog": {
-      "version": "5.0.1",
-      "requires": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
       }
     },
     "number-to-bn": {
@@ -19548,9 +19177,6 @@
         "send": "0.18.0"
       }
     },
-    "set-blocking": {
-      "version": "2.0.0"
-    },
     "setimmediate": {
       "version": "1.0.5"
     },
@@ -19591,7 +19217,8 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.7"
+      "version": "3.0.7",
+      "dev": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -19669,6 +19296,7 @@
     },
     "string-width": {
       "version": "4.2.3",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19797,22 +19425,6 @@
     "tapable": {
       "version": "2.2.1",
       "dev": true
-    },
-    "tar": {
-      "version": "6.1.13",
-      "requires": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^4.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4"
-        }
-      }
     },
     "terminal-link": {
       "version": "2.1.1",
@@ -20295,12 +19907,6 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.5",
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "windows-release": {

--- a/examples/bri-3/package.json
+++ b/examples/bri-3/package.json
@@ -29,6 +29,7 @@
     "@automapper/core": "^8.7.6",
     "@automapper/nestjs": "^8.7.6",
     "@casl/ability": "^6.3.3",
+    "@casl/prisma": "^1.3.3",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/cqrs": "^9.0.1",

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -1,14 +1,8 @@
-import {
-  ForcedSubject,
-  AbilityClass,
-  AbilityBuilder,
-  PureAbility,
-  subject,
-} from '@casl/ability';
+import { AbilityBuilder, PureAbility } from '@casl/ability';
 import { Injectable } from '@nestjs/common';
 import { BpiSubjectRoleName } from '../identity/bpiSubjects/models/bpiSubjectRole';
 import { BpiSubject as BpiSubjectModel } from '../identity/bpiSubjects/models/bpiSubject';
-import { BpiSubject, Workgroup, Prisma } from '@prisma/client';
+import { BpiSubject, Workgroup, Workflow, Workstep } from '@prisma/client';
 import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma';
 
 type AppSubjects =
@@ -16,6 +10,8 @@ type AppSubjects =
   | Subjects<{
       BpiSubject: BpiSubject;
       Workgroup: Workgroup;
+      Workstep: Workstep;
+      Workflow: Workflow;
     }>;
 export type AppAbility = PureAbility<[string, AppSubjects], PrismaQuery>;
 
@@ -39,6 +35,17 @@ const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
     can('read', 'Workgroup', onlyWorkgroupAdmin);
     can('update', 'Workgroup', onlyWorkgroupAdmin);
     can('delete', 'Workgroup', onlyWorkgroupAdmin);
+
+    const onlyWorkgroupAdminOfAssociatedWorkgroup = {
+      workgroup: { is: { administrators: { some: { id: bpiSubject.id } } } },
+    };
+    can('read', 'Workflow', onlyWorkgroupAdminOfAssociatedWorkgroup);
+    can('update', 'Workflow', onlyWorkgroupAdminOfAssociatedWorkgroup);
+    can('delete', 'Workflow', onlyWorkgroupAdminOfAssociatedWorkgroup);
+
+    can('read', 'Workstep', onlyWorkgroupAdminOfAssociatedWorkgroup);
+    can('update', 'Workstep', onlyWorkgroupAdminOfAssociatedWorkgroup);
+    can('delete', 'Workstep', onlyWorkgroupAdminOfAssociatedWorkgroup);
   },
 };
 

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -25,10 +25,10 @@ type DefinePermissions = (
 ) => void;
 
 const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
-  [BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
+  [BpiSubjectRoleName.INTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
     can('manage', 'all');
   },
-  [BpiSubjectRoleName.INTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
+  [BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
     can('read', 'BpiSubject', { id: bpiSubject.id });
     can('update', 'BpiSubject', { id: bpiSubject.id });
     can('delete', 'BpiSubject', { id: bpiSubject.id });

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -25,13 +25,20 @@ type DefinePermissions = (
 ) => void;
 
 const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
-  [BpiSubjectRoleName.INTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
+  [BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
     can('manage', 'all');
   },
-  [BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
+  [BpiSubjectRoleName.INTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
     can('read', 'BpiSubject', { id: bpiSubject.id });
     can('update', 'BpiSubject', { id: bpiSubject.id });
     can('delete', 'BpiSubject', { id: bpiSubject.id });
+
+    const onlyWorkgroupAdmin = {
+      administrators: { some: { id: bpiSubject.id } },
+    };
+    can('read', 'Workgroup', onlyWorkgroupAdmin);
+    can('update', 'Workgroup', onlyWorkgroupAdmin);
+    can('delete', 'Workgroup', onlyWorkgroupAdmin);
   },
 };
 

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -9,6 +9,8 @@ import {
   Workgroup,
   Workflow,
   Workstep,
+  Transaction,
+  Message,
 } from '@prisma/client';
 import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma';
 
@@ -21,6 +23,8 @@ type AppSubjects =
       Workflow: Workflow;
       BpiSubjectAccount: BpiSubjectAccount;
       BpiAccount: BpiAccount;
+      Transaction: Transaction;
+      Message: Message;
     }>;
 export type AppAbility = PureAbility<[string, AppSubjects], PrismaQuery>;
 

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -25,11 +25,13 @@ type DefinePermissions = (
 ) => void;
 
 const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
-  [BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
-    can('read', 'BpiSubject');
-  },
   [BpiSubjectRoleName.INTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
     can('manage', 'all');
+  },
+  [BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT](bpiSubject, { can }) {
+    can('read', 'BpiSubject', { id: bpiSubject.id });
+    can('update', 'BpiSubject', { id: bpiSubject.id });
+    can('delete', 'BpiSubject', { id: bpiSubject.id });
   },
 };
 

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -1,7 +1,6 @@
 import { AbilityBuilder, PureAbility } from '@casl/ability';
 import { Injectable } from '@nestjs/common';
 import { BpiSubjectRoleName } from '../identity/bpiSubjects/models/bpiSubjectRole';
-import { BpiSubject as BpiSubjectModel } from '../identity/bpiSubjects/models/bpiSubject';
 import {
   BpiSubject,
   BpiSubjectAccount,
@@ -11,6 +10,7 @@ import {
   Workstep,
   Transaction,
   Message,
+  BpiSubjectRole,
 } from '@prisma/client';
 import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma';
 
@@ -75,7 +75,9 @@ const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
 
 @Injectable()
 export class AuthzFactory {
-  buildAuthzFor(bpiSubject: BpiSubjectModel): AppAbility {
+  buildAuthzFor(
+    bpiSubject: BpiSubject & { roles: BpiSubjectRole[] },
+  ): AppAbility {
     const builder = new AbilityBuilder<AppAbility>(createPrismaAbility);
     // this is just for start, once there are more roles, this should be modified a bit
     const role = bpiSubject.roles[0]?.name;

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -5,6 +5,7 @@ import { BpiSubject as BpiSubjectModel } from '../identity/bpiSubjects/models/bp
 import {
   BpiSubject,
   BpiSubjectAccount,
+  BpiAccount,
   Workgroup,
   Workflow,
   Workstep,
@@ -19,6 +20,7 @@ type AppSubjects =
       Workstep: Workstep;
       Workflow: Workflow;
       BpiSubjectAccount: BpiSubjectAccount;
+      BpiAccount: BpiAccount;
     }>;
 export type AppAbility = PureAbility<[string, AppSubjects], PrismaQuery>;
 
@@ -57,6 +59,13 @@ const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
     can('read', 'BpiSubjectAccount', { ownerBpiSubjectId: bpiSubject.id });
     can('update', 'BpiSubjectAccount', { ownerBpiSubjectId: bpiSubject.id });
     can('delete', 'BpiSubjectAccount', { ownerBpiSubjectId: bpiSubject.id });
+
+    const onlyOwnerOfAssociatedBpiSubjectAccounts = {
+      ownerBpiSubjectAccounts: { some: { ownerBpiSubjectId: bpiSubject.id } },
+    };
+    can('read', 'BpiAccount', onlyOwnerOfAssociatedBpiSubjectAccounts);
+    can('update', 'BpiAccount', onlyOwnerOfAssociatedBpiSubjectAccounts);
+    can('delete', 'BpiAccount', onlyOwnerOfAssociatedBpiSubjectAccounts);
   },
 };
 

--- a/examples/bri-3/src/bri/authz/authz.factory.ts
+++ b/examples/bri-3/src/bri/authz/authz.factory.ts
@@ -2,7 +2,13 @@ import { AbilityBuilder, PureAbility } from '@casl/ability';
 import { Injectable } from '@nestjs/common';
 import { BpiSubjectRoleName } from '../identity/bpiSubjects/models/bpiSubjectRole';
 import { BpiSubject as BpiSubjectModel } from '../identity/bpiSubjects/models/bpiSubject';
-import { BpiSubject, Workgroup, Workflow, Workstep } from '@prisma/client';
+import {
+  BpiSubject,
+  BpiSubjectAccount,
+  Workgroup,
+  Workflow,
+  Workstep,
+} from '@prisma/client';
 import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma';
 
 type AppSubjects =
@@ -12,6 +18,7 @@ type AppSubjects =
       Workgroup: Workgroup;
       Workstep: Workstep;
       Workflow: Workflow;
+      BpiSubjectAccount: BpiSubjectAccount;
     }>;
 export type AppAbility = PureAbility<[string, AppSubjects], PrismaQuery>;
 
@@ -46,6 +53,10 @@ const rolePermissions: Record<BpiSubjectRoleName, DefinePermissions> = {
     can('read', 'Workstep', onlyWorkgroupAdminOfAssociatedWorkgroup);
     can('update', 'Workstep', onlyWorkgroupAdminOfAssociatedWorkgroup);
     can('delete', 'Workstep', onlyWorkgroupAdminOfAssociatedWorkgroup);
+
+    can('read', 'BpiSubjectAccount', { ownerBpiSubjectId: bpiSubject.id });
+    can('update', 'BpiSubjectAccount', { ownerBpiSubjectId: bpiSubject.id });
+    can('delete', 'BpiSubjectAccount', { ownerBpiSubjectId: bpiSubject.id });
   },
 };
 

--- a/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
@@ -3,8 +3,8 @@ import { SetMetadata } from '@nestjs/common';
 export const CHECK_AUTHZ = 'check_authz';
 
 export interface IRequirement {
-  action: any;
-  subject?: any;
+  action: string;
+  type: string;
 }
 
 export const CheckAuthz = (...requirements: IRequirement[]) =>

--- a/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
@@ -1,6 +1,6 @@
 import { SetMetadata } from '@nestjs/common';
 
-export const CHECK_AUTHZ = 'check_authz';
+export const CHECK_AUTHZ_METADATA_KEY = 'check_authz';
 
 export interface IRequirement {
   action: string;
@@ -8,4 +8,4 @@ export interface IRequirement {
 }
 
 export const CheckAuthz = (...requirements: IRequirement[]) =>
-  SetMetadata(CHECK_AUTHZ, requirements);
+  SetMetadata(CHECK_AUTHZ_METADATA_KEY, requirements);

--- a/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.decorator.ts
@@ -4,7 +4,7 @@ export const CHECK_AUTHZ = 'check_authz';
 
 export interface IRequirement {
   action: any;
-  subject: any;
+  subject?: any;
 }
 
 export const CheckAuthz = (...requirements: IRequirement[]) =>

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@casl/ability';
+import { ForbiddenError, subject } from '@casl/ability';
 import {
   CanActivate,
   ExecutionContext,
@@ -9,7 +9,6 @@ import { Reflector } from '@nestjs/core';
 import { PrismaService } from 'prisma/prisma.service';
 import { AuthzFactory } from '../authz.factory';
 import { CHECK_AUTHZ_METADATA_KEY, IRequirement } from './authz.decorator';
-import { subject } from '@casl/ability';
 import { IS_PUBLIC_ENDPOINT_METADATA_KEY } from '../../decorators/public-endpoint';
 
 // helper map to know which relations to include in generic prisma query
@@ -17,6 +16,16 @@ const prismaTypeToQueryIncludeMap = {
   BpiSubject: {},
   Workgroup: {
     administrators: true,
+  },
+  Workflow: {
+    workgroup: {
+      include: { administrators: true },
+    },
+  },
+  Workstep: {
+    workgroup: {
+      include: { administrators: true },
+    },
   },
 };
 

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -60,7 +60,7 @@ export class AuthzGuard implements CanActivate {
 
     const req = context.switchToHttp().getRequest();
     const subjectToAccessId = req.params.id;
-    const bpiSubjectToCheckAuthzFor = this.prisma.bpiSubject.findUnique({
+    const bpiSubjectToCheckAuthzFor = await this.prisma.bpiSubject.findUnique({
       where: {
         id: req.bpiSubject.id,
       },

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -27,6 +27,13 @@ const prismaTypeToQueryIncludeMap = {
       include: { administrators: true },
     },
   },
+  BpiAccount: {
+    ownerBpiSubjectAccounts: {
+      include: {
+        ownerBpiSubject: true,
+      },
+    },
+  },
 };
 
 @Injectable()

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -60,7 +60,15 @@ export class AuthzGuard implements CanActivate {
 
     const req = context.switchToHttp().getRequest();
     const subjectToAccessId = req.params.id;
-    const authz = this.authzFactory.buildAuthzFor(req.bpiSubject);
+    const bpiSubjectToCheckAuthzFor = this.prisma.bpiSubject.findUnique({
+      where: {
+        id: req.bpiSubject.id,
+      },
+      include: {
+        roles: true,
+      },
+    });
+    const authz = this.authzFactory.buildAuthzFor(bpiSubjectToCheckAuthzFor);
 
     try {
       for (const requirement of requirements) {

--- a/examples/bri-3/src/bri/authz/guards/authz.guard.ts
+++ b/examples/bri-3/src/bri/authz/guards/authz.guard.ts
@@ -11,6 +11,14 @@ import { AuthzFactory } from '../authz.factory';
 import { CHECK_AUTHZ, IRequirement } from './authz.decorator';
 import { subject } from '@casl/ability';
 
+// helper map to know which relations to include in generic prisma query
+const prismaTypeToQueryIncludeMap = {
+  BpiSubject: {},
+  Workgroup: {
+    administrators: true,
+  },
+};
+
 @Injectable()
 export class AuthzGuard implements CanActivate {
   constructor(
@@ -38,6 +46,7 @@ export class AuthzGuard implements CanActivate {
               requirement.type,
               await this.prisma[requirement.type].findUnique({
                 where: { id: subjectToAccessId },
+                include: prismaTypeToQueryIncludeMap[requirement.type],
               }),
             )
           : 'all';

--- a/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.ts
@@ -34,7 +34,7 @@ export class AccountController {
   }
 
   @Post()
-  @CheckAuthz({ action: 'manage', type: 'BpiAccount' })
+  @CheckAuthz({ action: 'create', type: 'BpiAccount' })
   async createBpiAccount(
     @Body() requestDto: CreateBpiAccountDto,
   ): Promise<string> {

--- a/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CheckAuthz } from '../../../authz/guards/authz.decorator';
 import { CreateBpiAccountCommand } from '../capabilities/createBpiAccount/createBpiAccount.command';
 import { DeleteBpiAccountCommand } from '../capabilities/deleteBpiAccount/deleteBpiAccount.command';
 import { GetAllBpiAccountsQuery } from '../capabilities/getAllBpiAccounts/getAllBpiAccounts.query';
@@ -21,16 +22,19 @@ export class AccountController {
   constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
 
   @Get('/:id')
+  @CheckAuthz({ action: 'read', type: 'BpiAccount' })
   async getBpiAccountById(@Param('id') id: string): Promise<BpiAccountDto> {
     return await this.queryBus.execute(new GetBpiAccountByIdQuery(id));
   }
 
   @Get()
+  @CheckAuthz({ action: 'read', type: 'BpiAccount' })
   async getAllBpiAccounts(): Promise<BpiAccountDto[]> {
     return await this.queryBus.execute(new GetAllBpiAccountsQuery());
   }
 
   @Post()
+  @CheckAuthz({ action: 'manage', type: 'BpiAccount' })
   async createBpiAccount(
     @Body() requestDto: CreateBpiAccountDto,
   ): Promise<string> {
@@ -40,11 +44,13 @@ export class AccountController {
   }
 
   @Put('/:id')
+  @CheckAuthz({ action: 'update', type: 'BpiAccount' })
   async updateBpiAccount(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new UpdateBpiAccountCommand(id));
   }
 
   @Delete('/:id')
+  @CheckAuthz({ action: 'delete', type: 'BpiAccount' })
   async deleteBpiAccount(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new DeleteBpiAccountCommand(id));
   }

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/api/subjectAccounts.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/api/subjectAccounts.controller.ts
@@ -39,7 +39,7 @@ export class SubjectAccountController {
   }
 
   @Post()
-  @CheckAuthz({ action: 'manage', type: 'BpiSubjectAccount' })
+  @CheckAuthz({ action: 'create', type: 'BpiSubjectAccount' })
   async createBpiSubjectAccount(
     @Body() requestDto: CreateBpiSubjectAccountDto,
   ): Promise<string> {

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/api/subjectAccounts.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/api/subjectAccounts.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CheckAuthz } from '../../../authz/guards/authz.decorator';
 import { CreateBpiSubjectAccountCommand } from '../capabilities/createBpiSubjectAccount/createBpiSubjectAccount.command';
 import { DeleteBpiSubjectAccountCommand } from '../capabilities/deleteBpiSubjectAccount/deleteBpiSubjectAccount.command';
 import { GetAllBpiSubjectAccountsQuery } from '../capabilities/getAllBpiSubjectAccounts/getAllBpiSubjectAccounts.query';
@@ -24,6 +25,7 @@ export class SubjectAccountController {
   // TODO: Response DTOs
   // TODO: DTO -> Command mapping
   @Get('/:id')
+  @CheckAuthz({ action: 'read', type: 'BpiSubjectAccount' })
   async getBpiSubjectAccountById(
     @Param('id') id: string,
   ): Promise<BpiSubjectAccountDto> {
@@ -31,11 +33,13 @@ export class SubjectAccountController {
   }
 
   @Get()
+  @CheckAuthz({ action: 'read', type: 'BpiSubjectAccount' })
   async getAllBpiSubjectAccounts(): Promise<BpiSubjectAccountDto[]> {
     return await this.queryBus.execute(new GetAllBpiSubjectAccountsQuery());
   }
 
   @Post()
+  @CheckAuthz({ action: 'manage', type: 'BpiSubjectAccount' })
   async createBpiSubjectAccount(
     @Body() requestDto: CreateBpiSubjectAccountDto,
   ): Promise<string> {
@@ -48,6 +52,7 @@ export class SubjectAccountController {
   }
 
   @Put('/:id')
+  @CheckAuthz({ action: 'update', type: 'BpiSubjectAccount' })
   async updateBpiSubjectAccount(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(
       new UpdateBpiSubjectAccountCommand(id),
@@ -55,6 +60,7 @@ export class SubjectAccountController {
   }
 
   @Delete('/:id')
+  @CheckAuthz({ action: 'delete', type: 'BpiSubjectAccount' })
   async deleteBpiSubjectAccount(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(
       new DeleteBpiSubjectAccountCommand(id),

--- a/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
@@ -23,17 +23,19 @@ export class SubjectController {
   constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
 
   @Get('/:id')
+  @CheckAuthz({ action: 'read' })
   async getBpiSubjectById(@Param('id') id: string): Promise<BpiSubjectDto> {
     return await this.queryBus.execute(new GetBpiSubjectByIdQuery(id));
   }
 
   @Get()
+  @CheckAuthz({ action: 'read' })
   async getAllBpiSubjects(): Promise<BpiSubjectDto[]> {
     return await this.queryBus.execute(new GetAllBpiSubjectsQuery());
   }
 
   @Post()
-  @CheckAuthz({ action: 'manage', subject: 'BpiSubject' })
+  @CheckAuthz({ action: 'create' })
   async createBpiSubject(
     @Body() requestDto: CreateBpiSubjectDto,
   ): Promise<string> {
@@ -47,6 +49,7 @@ export class SubjectController {
   }
 
   @Put('/:id')
+  @CheckAuthz({ action: 'update' })
   async updateBpiSubject(
     @Param('id') id: string,
     @Body() requestDto: UpdateBpiSubjectDto,
@@ -62,6 +65,7 @@ export class SubjectController {
   }
 
   @Delete('/:id')
+  @CheckAuthz({ action: 'delete' })
   async deleteBpiSubject(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new DeleteBpiSubjectCommand(id));
   }

--- a/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjects/api/subjects.controller.ts
@@ -23,19 +23,19 @@ export class SubjectController {
   constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
 
   @Get('/:id')
-  @CheckAuthz({ action: 'read' })
+  @CheckAuthz({ action: 'read', type: 'BpiSubject' })
   async getBpiSubjectById(@Param('id') id: string): Promise<BpiSubjectDto> {
     return await this.queryBus.execute(new GetBpiSubjectByIdQuery(id));
   }
 
   @Get()
-  @CheckAuthz({ action: 'read' })
+  @CheckAuthz({ action: 'read', type: 'BpiSubject' })
   async getAllBpiSubjects(): Promise<BpiSubjectDto[]> {
     return await this.queryBus.execute(new GetAllBpiSubjectsQuery());
   }
 
   @Post()
-  @CheckAuthz({ action: 'create' })
+  @CheckAuthz({ action: 'create', type: 'BpiSubject' })
   async createBpiSubject(
     @Body() requestDto: CreateBpiSubjectDto,
   ): Promise<string> {
@@ -49,7 +49,7 @@ export class SubjectController {
   }
 
   @Put('/:id')
-  @CheckAuthz({ action: 'update' })
+  @CheckAuthz({ action: 'update', type: 'BpiSubject' })
   async updateBpiSubject(
     @Param('id') id: string,
     @Body() requestDto: UpdateBpiSubjectDto,
@@ -65,7 +65,7 @@ export class SubjectController {
   }
 
   @Delete('/:id')
-  @CheckAuthz({ action: 'delete' })
+  @CheckAuthz({ action: 'delete', type: 'BpiSubject' })
   async deleteBpiSubject(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new DeleteBpiSubjectCommand(id));
   }

--- a/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.ts
@@ -35,7 +35,7 @@ export class WorkflowController {
   }
 
   @Post()
-  @CheckAuthz({ action: 'manage', type: 'Workflow' })
+  @CheckAuthz({ action: 'create', type: 'Workflow' })
   async createWorkflow(@Body() requestDto: CreateWorkflowDto): Promise<string> {
     return await this.commandBus.execute(
       new CreateWorkflowCommand(

--- a/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CheckAuthz } from '../../../authz/guards/authz.decorator';
 import { CreateWorkflowCommand } from '../capabilities/createWorkflow/createWorkflow.command';
 import { DeleteWorkflowCommand } from '../capabilities/deleteWorkflow/deleteWorkflow.command';
 import { GetAllWorkflowsQuery } from '../capabilities/getAllWorkflows/getAllWorkflows.query';
@@ -22,16 +23,19 @@ export class WorkflowController {
   constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
 
   @Get('/:id')
+  @CheckAuthz({ action: 'read', type: 'Workflow' })
   async getWorkflowById(@Param('id') id: string): Promise<WorkflowDto> {
     return await this.queryBus.execute(new GetWorkflowByIdQuery(id));
   }
 
   @Get()
+  @CheckAuthz({ action: 'read', type: 'Workflow' })
   async getAllWorkflows(): Promise<WorkflowDto[]> {
     return await this.queryBus.execute(new GetAllWorkflowsQuery());
   }
 
   @Post()
+  @CheckAuthz({ action: 'manage', type: 'Workflow' })
   async createWorkflow(@Body() requestDto: CreateWorkflowDto): Promise<string> {
     return await this.commandBus.execute(
       new CreateWorkflowCommand(
@@ -43,6 +47,7 @@ export class WorkflowController {
   }
 
   @Put('/:id')
+  @CheckAuthz({ action: 'update', type: 'Workflow' })
   async updateWorkflow(
     @Param('id') id: string,
     @Body() requestDto: UpdateWorkflowDto,
@@ -58,6 +63,7 @@ export class WorkflowController {
   }
 
   @Delete('/:id')
+  @CheckAuthz({ action: 'delete', type: 'Workflow' })
   async deleteWorkflow(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new DeleteWorkflowCommand(id));
   }

--- a/examples/bri-3/src/bri/workgroup/workgroups/api/workgroups.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/workgroups/api/workgroups.controller.ts
@@ -17,17 +17,20 @@ import { ArchiveWorkgroupCommand } from '../capabilities/archiveWorkgroup/archiv
 import { CreateWorkgroupDto } from './dtos/request/createWorkgroup.dto';
 import { UpdateWorkgroupDto } from './dtos/request/updateWorkgroup.dto';
 import { WorkgroupDto } from './dtos/response/workgroup.dto';
+import { CheckAuthz } from '../../../authz/guards/authz.decorator';
 
 @Controller('workgroups')
 export class WorkgroupController {
   constructor(private commandBus: CommandBus, private queryBus: QueryBus) {}
 
   @Get('/:id')
+  @CheckAuthz({ action: 'read', type: 'Workgroup' })
   async getWorkgroupById(@Param('id') id: string): Promise<WorkgroupDto> {
     return await this.queryBus.execute(new GetWorkgroupByIdQuery(id));
   }
 
   @Post()
+  @CheckAuthz({ action: 'manage', type: 'Workgroup' })
   async createWorkgroup(
     @Req() req,
     @Body() requestDto: CreateWorkgroupDto,
@@ -45,6 +48,7 @@ export class WorkgroupController {
   }
 
   @Put('/:id')
+  @CheckAuthz({ action: 'update', type: 'Workgroup' })
   async updateWorkgroup(
     @Param('id') id: string,
     @Body() requestDto: UpdateWorkgroupDto,
@@ -62,11 +66,13 @@ export class WorkgroupController {
   }
 
   @Put('archive/:id')
+  @CheckAuthz({ action: 'delete', type: 'Workgroup' })
   async archiveWorkgroup(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new ArchiveWorkgroupCommand(id));
   }
 
   @Delete('/:id')
+  @CheckAuthz({ action: 'delete', type: 'Workgroup' })
   async deleteWorkgroup(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new DeleteWorkgroupCommand(id));
   }

--- a/examples/bri-3/src/bri/workgroup/workgroups/api/workgroups.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/workgroups/api/workgroups.controller.ts
@@ -30,7 +30,7 @@ export class WorkgroupController {
   }
 
   @Post()
-  @CheckAuthz({ action: 'manage', type: 'Workgroup' })
+  @CheckAuthz({ action: 'create', type: 'Workgroup' })
   async createWorkgroup(
     @Req() req,
     @Body() requestDto: CreateWorkgroupDto,

--- a/examples/bri-3/src/bri/workgroup/worksteps/api/worksteps.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/worksteps/api/worksteps.controller.ts
@@ -38,7 +38,7 @@ export class WorkstepController {
   }
 
   @Post()
-  @CheckAuthz({ action: 'manage', type: 'Workstep' })
+  @CheckAuthz({ action: 'create', type: 'Workstep' })
   async createWorkstep(@Body() requestDto: CreateWorkstepDto): Promise<string> {
     return await this.commandBus.execute(
       new CreateWorkstepCommand(

--- a/examples/bri-3/src/bri/workgroup/worksteps/api/worksteps.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/worksteps/api/worksteps.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { CheckAuthz } from '../../../authz/guards/authz.decorator';
 import { CreateWorkstepCommand } from '../capabilities/createWorkstep/createWorkstep.command';
 import { DeleteWorkstepCommand } from '../capabilities/deleteWorkstep/deleteWorkstep.command';
 import { GetAllWorkstepsQuery } from '../capabilities/getAllWorksteps/getAllWorksteps.query';
@@ -25,16 +26,19 @@ export class WorkstepController {
   // TODO: Response DTOs
   // TODO: DTO -> Command mapping
   @Get('/:id')
+  @CheckAuthz({ action: 'read', type: 'Workstep' })
   async getWorkstepById(@Param('id') id: string): Promise<WorkstepDto> {
     return await this.queryBus.execute(new GetWorkstepByIdQuery(id));
   }
 
   @Get()
+  @CheckAuthz({ action: 'read', type: 'Workstep' })
   async getAllWorksteps(): Promise<WorkstepDto[]> {
     return await this.queryBus.execute(new GetAllWorkstepsQuery());
   }
 
   @Post()
+  @CheckAuthz({ action: 'manage', type: 'Workstep' })
   async createWorkstep(@Body() requestDto: CreateWorkstepDto): Promise<string> {
     return await this.commandBus.execute(
       new CreateWorkstepCommand(
@@ -49,6 +53,7 @@ export class WorkstepController {
   }
 
   @Put('/:id')
+  @CheckAuthz({ action: 'update', type: 'Workstep' })
   async updateWorkstep(
     @Param('id') id: string,
     @Body() requestDto: UpdateWorkstepDto,
@@ -67,6 +72,7 @@ export class WorkstepController {
   }
 
   @Delete('/:id')
+  @CheckAuthz({ action: 'delete', type: 'Workstep' })
   async deleteWorkstep(@Param('id') id: string): Promise<void> {
     return await this.commandBus.execute(new DeleteWorkstepCommand(id));
   }


### PR DESCRIPTION
# Description

This PR further extends on usage of casl library for authz.
- added casl prisma package to be able to define conditions on prisma models (https://casl.js.org/v6/en/package/casl-prisma) and modified authz factory accordingly
- made authz guard more generic with generic prisma query to fetch subject that is being affected 
- fixed the bug that caused public endpoints to still have this guard applied on

It contains these authz rules for controllers (assuming that internal bpi subject can manage all, this is just for external):
bpi subject - itself
workgroups - bpi subject that is workgroup admin
workflow/workstep - bpi subject that is workgroup admin that these are associated with
messages/transactions - probably best to leave to internal subject for now
subject account - owner bpi subject
bpi account - owner of associated bpi subject accounts owner

Purpose is to have minimal rules set for milestone 3, and if this is ok approach we could extend if needed when we have use case for milestone 4 with same/similar approach for new rules.

## Related Issue

https://github.com/eea-oasis/baseline/issues/634
https://github.com/eea-oasis/baseline/issues/635
https://github.com/eea-oasis/baseline/issues/636

## Motivation and Context

Check issues

## How Has This Been Tested

Using postman and various scenarios:
- internal bpi subject can manage all
- external can only crud its own bpi subject entity and workgroups where he is admin (this is my assumption)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
