### PR TITLE
Make logging print caller location instead

### DIFF
--- a/examples/bri-3/src/shared/logging/logging.service.ts
+++ b/examples/bri-3/src/shared/logging/logging.service.ts
@@ -7,7 +7,7 @@ export class LoggingService {
 
   constructor() {
     this._logger = new Logger({
-      ignoreStackLevels: 4
+      ignoreStackLevels: 4,
     });
   }
 

--- a/examples/bri-3/src/shared/logging/logging.service.ts
+++ b/examples/bri-3/src/shared/logging/logging.service.ts
@@ -6,7 +6,9 @@ export class LoggingService {
   private _logger: Logger;
 
   constructor() {
-    this._logger = new Logger();
+    this._logger = new Logger({
+      ignoreStackLevels: 4
+    });
   }
 
   public logError(message: string) {


### PR DESCRIPTION
# Description

<!--- Describe your changes in detail -->
After utilizing existing tslog settings, the logging prints the caller location instead. This change will impact all calls on LoggingService.

## Related Issue

#638

## How Has This Been Tested

I tried npm run start in backend and npm run test to verify the changes on logging.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/122571062/230106676-e8279b77-00ed-4edf-b914-9ed08c1b5b33.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I commit to abide by the Responsibilities of Code Owners/Maintainers.
