### PR TITLE
Feature/673 extend processpnboundmessagecommandhandler to allow for transaction creation

### DIFF
--- a/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessages.agent.ts
@@ -94,7 +94,7 @@ export class BpiMessageAgent {
     signature: string,
     type: BpiMessageType,
   ): BpiMessage {
-    return new BpiMessage(id, from, to, content, signature, type);
+    return new BpiMessage(id, from.id, to.id, content, signature, type);
   }
 
   public async fetchUpdateCandidateAndThrowIfUpdateValidationFails(

--- a/examples/bri-3/src/bri/communication/agents/bpiMessagesStorage.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/bpiMessagesStorage.agent.ts
@@ -44,8 +44,8 @@ export class BpiMessageStorageAgent extends PrismaService {
     const newBpiMessageModel = await this.message.create({
       data: {
         id: bpiMessage.id,
-        fromBpiSubjectId: bpiMessage.fromBpiSubject.id,
-        toBpiSubjectId: bpiMessage.toBpiSubject.id,
+        fromBpiSubjectId: bpiMessage.fromBpiSubjectId,
+        toBpiSubjectId: bpiMessage.toBpiSubjectId,
         content: await this.encryptionService.encrypt(bpiMessage.content),
         signature: bpiMessage.signature,
         type: bpiMessage.type,

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -1,3 +1,4 @@
+import { BpiMessageType } from '../models/bpiMessageType.enum';
 import { MessagingAgent } from './messaging.agent';
 
 let messagingAgent: MessagingAgent;
@@ -96,7 +97,7 @@ describe('Messaging Agent', () => {
   it('Should return error when validating correct JSON raw message with message type not being known', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 2}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 999}';
 
     // Act
     const [, validationErrors] =
@@ -104,10 +105,10 @@ describe('Messaging Agent', () => {
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual('type: 2 is unknown');
+    expect(validationErrors[0]).toEqual('type: 999 is unknown');
   });
 
-  it('Should return no errors and create message dto when validating correct JSON raw message', () => {
+  it('Should return no errors and create message dto when validating correct JSON raw message of INFO type', () => {
     // Arrange
     const rawMessage =
       '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 0}';
@@ -128,6 +129,30 @@ describe('Messaging Agent', () => {
     );
     expect(resultDto.content).toEqual({ testProp: 'testValue' });
     expect(resultDto.signature).toEqual('xyz');
-    expect(resultDto.type).toEqual(0);
+    expect(resultDto.type).toEqual(BpiMessageType.Info);
+  });
+
+  it('Should return no errors and create message dto when validating correct JSON raw message of TRANSACTION type', () => {
+    // Arrange
+    const rawMessage =
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
+
+    // Act
+    const [resultDto, validationErrors] =
+      messagingAgent.tryDeserializeToBpiMessageCandidate(rawMessage);
+
+    // Assert
+    expect(validationErrors.length).toBe(0);
+    expect(resultDto).toBeDefined();
+    expect(resultDto.id).toEqual('0a3dd67c-c031-4b50-95df-0bc5fc1c78b5');
+    expect(resultDto.fromBpiSubjectId).toEqual(
+      '71302cec-0a38-469a-a4e5-f58bdfc4ab32',
+    );
+    expect(resultDto.toBpiSubjectId).toEqual(
+      '76cdd901-d87d-4c87-b572-155afe45c128',
+    );
+    expect(resultDto.content).toEqual({ testProp: 'testValue' });
+    expect(resultDto.signature).toEqual('xyz');
+    expect(resultDto.type).toEqual(BpiMessageType.Transaction);
   });
 });

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -93,10 +93,10 @@ describe('Messaging Agent', () => {
     expect(validationErrors[0]).toEqual('signature is empty');
   });
 
-  it('Should return error when validating correct JSON raw message with message type not being info', () => {
+  it('Should return error when validating correct JSON raw message with message type not being known', () => {
     // Arrange
     const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
+      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 2}';
 
     // Act
     const [, validationErrors] =
@@ -104,7 +104,7 @@ describe('Messaging Agent', () => {
 
     // Assert
     expect(validationErrors.length).toBe(1);
-    expect(validationErrors[0]).toEqual('type: 1 is unknown');
+    expect(validationErrors[0]).toEqual('type: 2 is unknown');
   });
 
   it('Should return no errors and create message dto when validating correct JSON raw message', () => {

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -53,7 +53,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
       return false;
     }
 
-    if (newBpiMessageCandidate.isInfoMessage) {
+    if (newBpiMessageCandidate.isInfoMessage()) {
       return await this.commandBus.execute(
         new ProcessInboundBpiMessageCommand(
           newBpiMessageCandidate.id,
@@ -66,17 +66,17 @@ export class MessagingAgent implements OnApplicationBootstrap {
       );
     }
 
-    if (newBpiMessageCandidate.isTransactionMessage) {
+    if (newBpiMessageCandidate.isTransactionMessage()) {
       return await this.commandBus.execute(
         new ProcessInboundBpiTransactionCommand(
           newBpiMessageCandidate.id,
           1, // TODO: #669 Nonce
-          "TODO: #669 workflowInstanceId",
-          "TODO: #669 workstepInstanceId",
-          "TODO: #669 fromBpiSubjectAccountId",
-          "TODO: #669 toBpiSubjectAccountId",
+          'TODO: #669 workflowInstanceId',
+          'TODO: #669 workstepInstanceId',
+          'TODO: #669 fromBpiSubjectAccountId',
+          'TODO: #669 toBpiSubjectAccountId',
           JSON.stringify(newBpiMessageCandidate.content),
-          newBpiMessageCandidate.signature
+          newBpiMessageCandidate.signature,
         ),
       );
     }
@@ -89,15 +89,23 @@ export class MessagingAgent implements OnApplicationBootstrap {
     let newBpiMessageCandidate: BpiMessage;
 
     try {
-      newBpiMessageCandidate = this.parseJsonOrThrow(rawMessage);
+      const newBpiMessageProps = this.parseJsonOrThrow(rawMessage);
+      newBpiMessageCandidate = new BpiMessage(
+        newBpiMessageProps.id,
+        newBpiMessageProps.fromBpiSubjectId,
+        newBpiMessageProps.toBpiSubjectId,
+        newBpiMessageProps.content,
+        newBpiMessageProps.signature,
+        newBpiMessageProps.type,
+      );
     } catch (e) {
       errors.push(`${rawMessage} is not valid JSON. Error: ${e}`);
       return [newBpiMessageCandidate, errors];
     }
 
     if (
-      !newBpiMessageCandidate.isInfoMessage &&
-      !newBpiMessageCandidate.isTransactionMessage
+      !newBpiMessageCandidate.isInfoMessage() &&
+      !newBpiMessageCandidate.isTransactionMessage()
     ) {
       errors.push(`type: ${newBpiMessageCandidate.type} is unknown`);
       return [null, errors];
@@ -135,7 +143,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
       errors.push('signature is empty');
     }
 
-    if (newBpiMessageCandidate.isTransactionMessage) {
+    if (newBpiMessageCandidate.isTransactionMessage()) {
       // TODO: Perform additional transaction specific validation once #669 is done
     }
 

--- a/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
+++ b/examples/bri-3/src/bri/communication/api/messages.controller.spec.ts
@@ -67,8 +67,8 @@ describe('MessageController', () => {
 
     existingBpiMessage = new BpiMessage(
       'f3e4295d-6a2a-4f04-8477-02f781eb93f8',
-      existingBpiSubject1,
-      existingBpiSubject2,
+      existingBpiSubject1.id,
+      existingBpiSubject2.id,
       'hello world',
       'xyz',
       0,
@@ -256,8 +256,8 @@ describe('MessageController', () => {
 
       const expectedBpiMessage = new BpiMessage(
         requestDto.id,
-        existingBpiSubject1,
-        existingBpiSubject2,
+        existingBpiSubject1.id,
+        existingBpiSubject2.id,
         requestDto.content,
         requestDto.signature,
         requestDto.type,

--- a/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
+++ b/examples/bri-3/src/bri/communication/capabilities/processInboundMessage/processInboundMessageCommand.handler.ts
@@ -6,7 +6,7 @@ import { MessagingAgent } from '../../agents/messaging.agent';
 import { ProcessInboundBpiMessageCommand } from './processInboundMessage.command';
 
 // Difference between this and the create bpi message command handler is that this one does not
-// want to stop the execution flow by throwing a nestjs exception (which results in 404 response in the other handler)
+// stop the execution flow by throwing a nestjs exception (which results in 404 response in the other handler)
 // TODO: Consider using a NestJs Saga or another command dispatch to avoid code duplication
 @CommandHandler(ProcessInboundBpiMessageCommand)
 export class ProcessInboundMessageCommandHandler

--- a/examples/bri-3/src/bri/communication/models/bpiMessage.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessage.ts
@@ -29,15 +29,15 @@ export class BpiMessage {
 
   constructor(
     id: string,
-    from: BpiSubject,
-    to: BpiSubject,
+    fromBpiSubjectId: string,
+    toBpiSubjectId: string,
     content: string,
     signature: string,
     type: BpiMessageType,
   ) {
     this.id = id;
-    this.fromBpiSubject = from;
-    this.toBpiSubject = to;
+    this.fromBpiSubjectId = fromBpiSubjectId;
+    this.toBpiSubjectId = toBpiSubjectId;
     this.content = content;
     this.signature = signature;
     this.type = type;

--- a/examples/bri-3/src/bri/communication/models/bpiMessage.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessage.ts
@@ -50,4 +50,12 @@ export class BpiMessage {
   public updateSignature(newSignature: string): void {
     this.signature = newSignature;
   }
+
+  public isInfoMessage(): boolean {
+    return this.type === BpiMessageType.Info;
+  }
+
+  public isTransactionMessage(): boolean {
+    return this.type === BpiMessageType.Transaction;
+  }
 }

--- a/examples/bri-3/src/bri/communication/models/bpiMessageType.enum.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessageType.enum.ts
@@ -1,3 +1,4 @@
 export enum BpiMessageType {
   Info,
+  Transaction,
 }

--- a/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.spec.ts
+++ b/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.spec.ts
@@ -222,9 +222,15 @@ describe('AccountController', () => {
     it('should return new uuid from the created bpi account when all params provided', async () => {
       // Arrange
       const bpiSubjectAccount = createBpiSubjectAccount();
+
+      subjectAccountStorageAgentMock.getBpiSubjectAccountById.mockResolvedValueOnce(
+        bpiSubjectAccount,
+      );
+
       const requestDto = {
         ownerBpiSubjectAccountsIds: [bpiSubjectAccount.id],
       } as CreateBpiAccountDto;
+
       const expectedBpiAcount = createBpiAccount([bpiSubjectAccount]);
       accountStorageAgentMock.storeNewBpiAccount.mockResolvedValueOnce(
         expectedBpiAcount,

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
@@ -18,7 +18,7 @@ export class BpiSubjectAccountAgent {
 
   public async getBpiSubjectAccountsAndThrowIfNotExist(
     subjectAccountIds: string[],
-  ) {
+  ): Promise<BpiSubjectAccount[]> {
     const subjectAccounts: BpiSubjectAccount[] = [];
 
     for (const subjectAccountId of subjectAccountIds) {
@@ -26,11 +26,34 @@ export class BpiSubjectAccountAgent {
         await this.subjectAccountStorageAgent.getBpiSubjectAccountById(
           subjectAccountId,
         );
+
+      if (subjectAccount == null) {
+        throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+      }
+
       subjectAccounts.push(subjectAccount);
     }
 
     return subjectAccounts;
   }
+
+  public async getBpiSubjectAccounts(subjectAccountIds: string[]): Promise<BpiSubjectAccount[]> {
+    const subjectAccounts: BpiSubjectAccount[] = [];
+
+    for (const subjectAccountId of subjectAccountIds) {
+      const subjectAccount =
+        await this.subjectAccountStorageAgent.getBpiSubjectAccountById(
+          subjectAccountId,
+        );
+
+      if (subjectAccount !== null) {
+        subjectAccounts.push(subjectAccount);
+      }
+    }
+
+    return subjectAccounts;
+  }
+
 
   public async getCreatorAndOwnerSubjectsAndThrowIfNotExist(
     creatorBpiSubjectId: string,

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent.ts
@@ -37,7 +37,9 @@ export class BpiSubjectAccountAgent {
     return subjectAccounts;
   }
 
-  public async getBpiSubjectAccounts(subjectAccountIds: string[]): Promise<BpiSubjectAccount[]> {
+  public async getBpiSubjectAccounts(
+    subjectAccountIds: string[],
+  ): Promise<BpiSubjectAccount[]> {
     const subjectAccounts: BpiSubjectAccount[] = [];
 
     for (const subjectAccountId of subjectAccountIds) {
@@ -53,7 +55,6 @@ export class BpiSubjectAccountAgent {
 
     return subjectAccounts;
   }
-
 
   public async getCreatorAndOwnerSubjectsAndThrowIfNotExist(
     creatorBpiSubjectId: string,

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccountsStorage.agent.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccountsStorage.agent.ts
@@ -21,7 +21,7 @@ export class BpiSubjectAccountStorageAgent extends PrismaService {
     });
 
     if (!bpiSubjectAccountModel) {
-      throw new NotFoundException(NOT_FOUND_ERR_MESSAGE);
+      return null;
     }
 
     return this.mapper.map(

--- a/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
+++ b/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
@@ -17,7 +17,7 @@ import { BpiSubjectAccount } from '../../identity/bpiSubjectAccounts/models/bpiS
 @Injectable()
 export class TransactionAgent {
   constructor(private storageAgent: TransactionStorageAgent) {}
- 
+
   public throwIfCreateTransactionInputInvalid() {
     // TODO: This is a placeholder, we will add validation rules as we move forward with business logic implementation
     return true;

--- a/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
+++ b/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
@@ -17,7 +17,13 @@ import { BpiSubjectAccount } from '../../identity/bpiSubjectAccounts/models/bpiS
 @Injectable()
 export class TransactionAgent {
   constructor(private storageAgent: TransactionStorageAgent) {}
+ 
   public throwIfCreateTransactionInputInvalid() {
+    // TODO: This is a placeholder, we will add validation rules as we move forward with business logic implementation
+    return true;
+  }
+
+  public isCreateTransactionInputInvalid(): boolean {
     // TODO: This is a placeholder, we will add validation rules as we move forward with business logic implementation
     return true;
   }

--- a/examples/bri-3/src/bri/transactions/api/transactions.controller.spec.ts
+++ b/examples/bri-3/src/bri/transactions/api/transactions.controller.spec.ts
@@ -28,6 +28,7 @@ import { uuid } from 'uuidv4';
 describe('TransactionController', () => {
   let controller: TransactionController;
   let transactionStorageAgentMock: DeepMockProxy<TransactionStorageAgent>;
+  let subjectAccountStorageAgentMock: DeepMockProxy<BpiSubjectAccountStorageAgent>;
 
   const createBpiSubjectAccount = (id: string) => {
     const ownerBpiSubject = new BpiSubject(
@@ -88,6 +89,8 @@ describe('TransactionController', () => {
 
     controller = app.get<TransactionController>(TransactionController);
     transactionStorageAgentMock = app.get(TransactionStorageAgent);
+    subjectAccountStorageAgentMock = app.get(BpiSubjectAccountStorageAgent);
+
     await app.init();
   });
 
@@ -157,6 +160,14 @@ describe('TransactionController', () => {
       // Arrange
       const fromBpiSubjectAccount = createBpiSubjectAccount(uuid());
       const toBpiSubjectAccount = createBpiSubjectAccount(uuid());
+
+      subjectAccountStorageAgentMock.getBpiSubjectAccountById
+        .calledWith(fromBpiSubjectAccount.id)
+        .mockResolvedValueOnce(fromBpiSubjectAccount);
+
+      subjectAccountStorageAgentMock.getBpiSubjectAccountById
+        .calledWith(toBpiSubjectAccount.id)
+        .mockResolvedValueOnce(toBpiSubjectAccount);
 
       const requestDto = {
         id: uuid(),

--- a/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransactionCommand.handler.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransactionCommand.handler.ts
@@ -16,7 +16,7 @@ export class CreateTransactionCommandHandler
 
   async execute(command: CreateTransactionCommand) {
     this.agent.throwIfCreateTransactionInputInvalid();
-    
+
     const subjectAccounts =
       await this.subjectAccountAgent.getBpiSubjectAccountsAndThrowIfNotExist([
         command.fromSubjectAccountId,

--- a/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransactionCommand.handler.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/createTransaction/createTransactionCommand.handler.ts
@@ -16,6 +16,7 @@ export class CreateTransactionCommandHandler
 
   async execute(command: CreateTransactionCommand) {
     this.agent.throwIfCreateTransactionInputInvalid();
+    
     const subjectAccounts =
       await this.subjectAccountAgent.getBpiSubjectAccountsAndThrowIfNotExist([
         command.fromSubjectAccountId,

--- a/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransaction.command.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransaction.command.ts
@@ -1,0 +1,12 @@
+export class ProcessInboundBpiTransactionCommand {
+  constructor(
+    public readonly id: string,
+    public readonly nonce: number,
+    public readonly workflowInstanceId: string,
+    public readonly workstepInstanceId: string,
+    public readonly fromSubjectAccountId: string,
+    public readonly toSubjectAccountId: string,
+    public readonly payload: string,
+    public readonly signature: string,
+  ) {}
+}

--- a/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransactionCommand.handler.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransactionCommand.handler.ts
@@ -25,7 +25,10 @@ export class ProcessInboundTransactionCommandHandler
     }
 
     const subjectAccounts =
-      await this.subjectAccountAgent.getBpiSubjectAccounts([command.fromSubjectAccountId, command.toSubjectAccountId]);
+      await this.subjectAccountAgent.getBpiSubjectAccounts([
+        command.fromSubjectAccountId,
+        command.toSubjectAccountId,
+      ]);
 
     if (subjectAccounts.length !== 2) {
       return false;
@@ -52,9 +55,7 @@ export class ProcessInboundTransactionCommandHandler
       command.signature,
     );
 
-    await this.storageAgent.createNewTransaction(
-      newTransactionCandidate,
-    );
+    await this.storageAgent.createNewTransaction(newTransactionCandidate);
 
     return true;
   }

--- a/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransactionCommand.handler.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransactionCommand.handler.ts
@@ -55,7 +55,7 @@ export class ProcessInboundTransactionCommandHandler
       command.signature,
     );
 
-    await this.storageAgent.createNewTransaction(newTransactionCandidate);
+    await this.storageAgent.storeNewTransaction(newTransactionCandidate);
 
     return true;
   }

--- a/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransactionCommand.handler.ts
+++ b/examples/bri-3/src/bri/transactions/capabilities/processInboundTransaction/processInboundTransactionCommand.handler.ts
@@ -1,0 +1,61 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { BpiSubjectAccountAgent } from 'src/bri/identity/bpiSubjectAccounts/agents/bpiSubjectAccounts.agent';
+import { AuthAgent } from '../../../auth/agent/auth.agent';
+import { TransactionAgent } from '../../agents/transactions.agent';
+import { TransactionStorageAgent } from '../../agents/transactionStorage.agent';
+import { ProcessInboundBpiTransactionCommand } from './processInboundTransaction.command';
+
+// Difference between this and the create bpi transaction command handler is that this one does not
+// stop the execution flow by throwing a nestjs exception (which results in 404 response in the other handler)
+// TODO: Consider using a NestJs Saga or another command dispatch to avoid code duplication
+@CommandHandler(ProcessInboundBpiTransactionCommand)
+export class ProcessInboundTransactionCommandHandler
+  implements ICommandHandler<ProcessInboundBpiTransactionCommand>
+{
+  constructor(
+    private agent: TransactionAgent,
+    private storageAgent: TransactionStorageAgent,
+    private subjectAccountAgent: BpiSubjectAccountAgent,
+    private readonly authAgent: AuthAgent,
+  ) {}
+
+  async execute(command: ProcessInboundBpiTransactionCommand) {
+    if (this.agent.isCreateTransactionInputInvalid()) {
+      return false;
+    }
+
+    const subjectAccounts =
+      await this.subjectAccountAgent.getBpiSubjectAccounts([command.fromSubjectAccountId, command.toSubjectAccountId]);
+
+    if (subjectAccounts.length !== 2) {
+      return false;
+    }
+
+    const isSignatureValid = this.authAgent.verifySignatureAgainstPublicKey(
+      command.payload,
+      command.signature,
+      subjectAccounts[0].ownerBpiSubject.publicKey,
+    );
+
+    if (!isSignatureValid) {
+      return false;
+    }
+
+    const newTransactionCandidate = this.agent.createNewTransaction(
+      command.id,
+      command.nonce,
+      command.workflowInstanceId,
+      command.workstepInstanceId,
+      subjectAccounts[0],
+      subjectAccounts[1],
+      command.payload,
+      command.signature,
+    );
+
+    await this.storageAgent.createNewTransaction(
+      newTransactionCandidate,
+    );
+
+    return true;
+  }
+}


### PR DESCRIPTION
# Description

Introduces BpiMessage Transaction type and additional infrastructure that enables triggering of a command to create a BpiTransaction from a NATS incoming message which is properly formatted. Contains a number of TODOs that will be tackled as part of #669 

## Related Issue

#673
#669 

## Motivation and Context

Standard defines that a BpiTransaction can be triggered through a BpiMessage send via a messaging system utilized by the BPI.

## How Has This Been Tested

Wrote new unit test and ran unit and e2e tests

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
