### PR TITLE
Feature/668 add reference to bpi account in a workflow

### DIFF
--- a/examples/bri-3/prisma/migrations/20230721203711_add_bpi_account_to_workflow/migration.sql
+++ b/examples/bri-3/prisma/migrations/20230721203711_add_bpi_account_to_workflow/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `bpiAccountId` to the `Workflow` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Workflow" ADD COLUMN     "bpiAccountId" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Workflow" ADD CONSTRAINT "Workflow_bpiAccountId_fkey" FOREIGN KEY ("bpiAccountId") REFERENCES "BpiAccount"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/examples/bri-3/prisma/migrations/20230731194923_add_workstep_id_and_bpi_subject_account_id_to_bpi_message/migration.sql
+++ b/examples/bri-3/prisma/migrations/20230731194923_add_workstep_id_and_bpi_subject_account_id_to_bpi_message/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "fromBpiSubjectAccountId" TEXT,
+ADD COLUMN     "toBpiSubjectAccountId" TEXT,
+ADD COLUMN     "workstepId" TEXT;

--- a/examples/bri-3/prisma/migrations/20230731195946_add_nonce_to_bpi_message/migration.sql
+++ b/examples/bri-3/prisma/migrations/20230731195946_add_nonce_to_bpi_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "nonce" INTEGER;

--- a/examples/bri-3/prisma/migrations/20230731200841_add_workflow_id_to_bpi_message/migration.sql
+++ b/examples/bri-3/prisma/migrations/20230731200841_add_workflow_id_to_bpi_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN     "workflowId" TEXT;

--- a/examples/bri-3/prisma/schema.prisma
+++ b/examples/bri-3/prisma/schema.prisma
@@ -115,6 +115,7 @@ model Message {
   fromBpiSubjectAccountId String?
   toBpiSubjectAccountId   String?
   workstepId              String?
+  nonce                   Int?
   content                 String
   signature               String
   type                    Int

--- a/examples/bri-3/prisma/schema.prisma
+++ b/examples/bri-3/prisma/schema.prisma
@@ -11,50 +11,51 @@ datasource db {
 }
 
 model BpiSubject {
-  id                          String                 @id @default(uuid())
-  name                        String
-  description                 String
-  publicKey                   String
-  loginNonce                  String                 @default("")
-  ownedBpiSubjectAccounts     BpiSubjectAccount[]    @relation(name: "ownerBpiSubject_fk")
-  createdBpiSubjectAccounts   BpiSubjectAccount[]    @relation(name: "creatorBpiSubject_fk")
-  sentMessages                Message[]              @relation(name: "fromBpiSubject_fk")
-  receivedMessages            Message[]              @relation(name: "toBpiSubject_fk")
-  administratedWorkgroups     Workgroup[]            @relation(name: "administratorSubjects")
-  participatingWorkgroups     Workgroup[]            @relation(name: "participantSubjects") 
-  roles                       BpiSubjectRole[]
-  ownedAnchorHashes           AnchorHash[]          @relation(name: "anchorHashOwnerBpiSubject_fk")       
+  id                        String              @id @default(uuid())
+  name                      String
+  description               String
+  publicKey                 String
+  loginNonce                String              @default("")
+  ownedBpiSubjectAccounts   BpiSubjectAccount[] @relation(name: "ownerBpiSubject_fk")
+  createdBpiSubjectAccounts BpiSubjectAccount[] @relation(name: "creatorBpiSubject_fk")
+  sentMessages              Message[]           @relation(name: "fromBpiSubject_fk")
+  receivedMessages          Message[]           @relation(name: "toBpiSubject_fk")
+  administratedWorkgroups   Workgroup[]         @relation(name: "administratorSubjects")
+  participatingWorkgroups   Workgroup[]         @relation(name: "participantSubjects")
+  roles                     BpiSubjectRole[]
+  ownedAnchorHashes         AnchorHash[]        @relation(name: "anchorHashOwnerBpiSubject_fk")
 }
 
 model BpiSubjectRole {
-  id                          String                 @id @default(uuid())
-  name                        String                 @unique
-  description                 String
-  bpiSubjects                 BpiSubject[]           
+  id          String       @id @default(uuid())
+  name        String       @unique
+  description String
+  bpiSubjects BpiSubject[]
 }
 
 model BpiAccount {
-  id                      String                    @id @default(uuid())
-  nonce                   Int     
-  ownerBpiSubjectAccounts BpiSubjectAccount[]     
-  authorizationCondition  String                    @default("") //Placeholder R251
-  stateObjectProverSystem String                    @default("") //Placeholder R251
-  stateObjectStorage      String                    @default("") //Placeholder R251
+  id                      String              @id @default(uuid())
+  nonce                   Int
+  ownerBpiSubjectAccounts BpiSubjectAccount[]
+  authorizationCondition  String              @default("") //Placeholder R251
+  stateObjectProverSystem String              @default("") //Placeholder R251
+  stateObjectStorage      String              @default("") //Placeholder R251
+  Workflow                Workflow[]
 }
 
 model BpiSubjectAccount {
-  id                        String            @id @default(uuid())
-  creatorBpiSubjectId       String    
-  ownerBpiSubjectId         String    
-  authenticationPolicy      String            @default("") //Placeholder R80
-  authorizationPolicy       String            @default("") //Placeholder R80
-  verifiableCredential      String            @default("") //Placeholder R80
-  recoveryKey               String            @default("") //Placeholder R80
-  bpiAccounts               BpiAccount[]    
-  creatorBpiSubject         BpiSubject        @relation(fields: [creatorBpiSubjectId], references: [id], name: "creatorBpiSubject_fk")
-  ownerBpiSubject           BpiSubject        @relation(fields: [ownerBpiSubjectId], references: [id], name: "ownerBpiSubject_fk")
-  sentTransactions          Transaction[]     @relation(name: "fromBpiSubjectAccount_fk")
-  receivedTransactions      Transaction[]     @relation(name: "toBpiSubjectAccount_fk")
+  id                   String        @id @default(uuid())
+  creatorBpiSubjectId  String
+  ownerBpiSubjectId    String
+  authenticationPolicy String        @default("") //Placeholder R80
+  authorizationPolicy  String        @default("") //Placeholder R80
+  verifiableCredential String        @default("") //Placeholder R80
+  recoveryKey          String        @default("") //Placeholder R80
+  bpiAccounts          BpiAccount[]
+  creatorBpiSubject    BpiSubject    @relation(fields: [creatorBpiSubjectId], references: [id], name: "creatorBpiSubject_fk")
+  ownerBpiSubject      BpiSubject    @relation(fields: [ownerBpiSubjectId], references: [id], name: "ownerBpiSubject_fk")
+  sentTransactions     Transaction[] @relation(name: "fromBpiSubjectAccount_fk")
+  receivedTransactions Transaction[] @relation(name: "toBpiSubjectAccount_fk")
 }
 
 model Workstep {
@@ -70,37 +71,39 @@ model Workstep {
 }
 
 model Workflow {
-  id          String     @id @default(uuid())
-  name        String
-  workgroupId String
-  worksteps   Workstep[]
-  workgroup   Workgroup  @relation(fields: [workgroupId], references: [id])
+  id           String     @id @default(uuid())
+  name         String
+  workgroupId  String
+  worksteps    Workstep[]
+  workgroup    Workgroup  @relation(fields: [workgroupId], references: [id])
+  bpiAccountId String
+  bpiAccount   BpiAccount @relation(fields: [bpiAccountId], references: [id])
 }
 
 model Workgroup {
-  id             String                       @id @default(uuid())
+  id             String          @id @default(uuid())
   name           String
-  administrators BpiSubject[] @relation(name: "administratorSubjects")
+  administrators BpiSubject[]    @relation(name: "administratorSubjects")
   securityPolicy String
   privacyPolicy  String
-  participants   BpiSubject[] @relation(name: "participantSubjects")
+  participants   BpiSubject[]    @relation(name: "participantSubjects")
   workflows      Workflow[]
   worksteps      Workstep[]
-  status         WorkgroupStatus       @default(ACTIVE)
+  status         WorkgroupStatus @default(ACTIVE)
 }
 
 model Transaction {
-  id String @id
-  nonce Int
-  workflowInstanceId String
-  workstepInstanceId String
+  id                      String            @id
+  nonce                   Int
+  workflowInstanceId      String
+  workstepInstanceId      String
   fromBpiSubjectAccountId String
-  fromBpiSubjectAccount BpiSubjectAccount @relation(fields: [fromBpiSubjectAccountId], references: [id], name: "fromBpiSubjectAccount_fk")
-  toBpiSubjectAccountId String
-  toBpiSubjectAccount BpiSubjectAccount @relation(fields: [toBpiSubjectAccountId], references: [id], name: "toBpiSubjectAccount_fk")
-  payload String
-  signature String
-  status Int
+  fromBpiSubjectAccount   BpiSubjectAccount @relation(fields: [fromBpiSubjectAccountId], references: [id], name: "fromBpiSubjectAccount_fk")
+  toBpiSubjectAccountId   String
+  toBpiSubjectAccount     BpiSubjectAccount @relation(fields: [toBpiSubjectAccountId], references: [id], name: "toBpiSubjectAccount_fk")
+  payload                 String
+  signature               String
+  status                  Int
 }
 
 model Message {
@@ -115,16 +118,16 @@ model Message {
 }
 
 model AnchorHash {
-  id                String     @id @default(uuid()) 
+  id                String     @id @default(uuid())
   ownerBpiSubjectId String
-  ownerBpiSubject   BpiSubject @relation(fields: [ownerBpiSubjectId], references: [id], name: "anchorHashOwnerBpiSubject_fk")    
+  ownerBpiSubject   BpiSubject @relation(fields: [ownerBpiSubjectId], references: [id], name: "anchorHashOwnerBpiSubject_fk")
   hash              String     @unique
 }
 
 model BpiMerkleTree {
-  id                String @id @default(uuid())
-  hashAlgName       String
-  tree              String
+  id          String @id @default(uuid())
+  hashAlgName String
+  tree        String
 }
 
 enum WorkgroupStatus {

--- a/examples/bri-3/prisma/schema.prisma
+++ b/examples/bri-3/prisma/schema.prisma
@@ -107,14 +107,17 @@ model Transaction {
 }
 
 model Message {
-  id               String     @id
-  fromBpiSubjectId String
-  fromBpiSubject   BpiSubject @relation(fields: [fromBpiSubjectId], references: [id], name: "fromBpiSubject_fk")
-  toBpiSubjectId   String
-  toBpiSubject     BpiSubject @relation(fields: [toBpiSubjectId], references: [id], name: "toBpiSubject_fk")
-  content          String
-  signature        String
-  type             Int
+  id                      String     @id
+  fromBpiSubjectId        String
+  fromBpiSubject          BpiSubject @relation(fields: [fromBpiSubjectId], references: [id], name: "fromBpiSubject_fk")
+  toBpiSubjectId          String
+  toBpiSubject            BpiSubject @relation(fields: [toBpiSubjectId], references: [id], name: "toBpiSubject_fk")
+  fromBpiSubjectAccountId String?
+  toBpiSubjectAccountId   String?
+  workstepId              String?
+  content                 String
+  signature               String
+  type                    Int
 }
 
 model AnchorHash {

--- a/examples/bri-3/prisma/schema.prisma
+++ b/examples/bri-3/prisma/schema.prisma
@@ -114,6 +114,7 @@ model Message {
   toBpiSubject            BpiSubject @relation(fields: [toBpiSubjectId], references: [id], name: "toBpiSubject_fk")
   fromBpiSubjectAccountId String?
   toBpiSubjectAccountId   String?
+  workflowId              String?
   workstepId              String?
   nonce                   Int?
   content                 String

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.spec.ts
@@ -151,8 +151,18 @@ describe('Messaging Agent', () => {
 
   it('Should return no errors and create message dto when validating correct JSON raw message of TRANSACTION type', () => {
     // Arrange
-    const rawMessage =
-      '{ "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32", "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128", "content": { "testProp":"testValue" }, "signature": "xyz", "type": 1}';
+    const rawMessage = `{ 
+          "id": "0a3dd67c-c031-4b50-95df-0bc5fc1c78b5", 
+          "fromBpiSubjectId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32",
+          "toBpiSubjectId": "76cdd901-d87d-4c87-b572-155afe45c128",
+          "fromBpiSubjectAccountId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32",
+          "toBpiSubjectAccountId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32",
+          "workflowId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32",
+          "workstepId": "71302cec-0a38-469a-a4e5-f58bdfc4ab32",
+          "content": { "testProp":"testValue" }, 
+          "signature": "xyz", 
+          "type": 1
+        }`;
 
     // Act
     const [resultDto, validationErrors] =

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -92,6 +92,7 @@ export class MessagingAgent implements OnApplicationBootstrap {
 
     try {
       const newBpiMessageProps = this.parseJsonOrThrow(rawMessage);
+
       newBpiMessageCandidate = new BpiMessage(
         newBpiMessageProps.id,
         newBpiMessageProps.fromBpiSubjectId,
@@ -100,6 +101,15 @@ export class MessagingAgent implements OnApplicationBootstrap {
         newBpiMessageProps.signature,
         newBpiMessageProps.type,
       );
+
+      newBpiMessageCandidate.updateFromBpiSubjectAccountId(
+        newBpiMessageProps.fromBpiSubjectAccountId,
+      );
+      newBpiMessageCandidate.updateToBpiSubjectAccountId(
+        newBpiMessageProps.toBpiSubjectAccountId,
+      );
+      newBpiMessageCandidate.updateWorkflowId(newBpiMessageProps.workflowId);
+      newBpiMessageCandidate.updateWorkstepId(newBpiMessageProps.workstepId);
     } catch (e) {
       errors.push(`${rawMessage} is not valid JSON. Error: ${e}`);
       return [newBpiMessageCandidate, errors];

--- a/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
+++ b/examples/bri-3/src/bri/communication/agents/messaging.agent.ts
@@ -70,11 +70,11 @@ export class MessagingAgent implements OnApplicationBootstrap {
       return await this.commandBus.execute(
         new ProcessInboundBpiTransactionCommand(
           newBpiMessageCandidate.id,
-          1, // TODO: #669 Nonce
-          'TODO: #669 workflowInstanceId',
-          'TODO: #669 workstepInstanceId',
-          'TODO: #669 fromBpiSubjectAccountId',
-          'TODO: #669 toBpiSubjectAccountId',
+          newBpiMessageCandidate.nonce,
+          newBpiMessageCandidate.workflowId,
+          newBpiMessageCandidate.workstepId,
+          newBpiMessageCandidate.fromBpiSubjectAccountId,
+          newBpiMessageCandidate.toBpiSubjectAccountId,
           JSON.stringify(newBpiMessageCandidate.content),
           newBpiMessageCandidate.signature,
         ),
@@ -146,7 +146,29 @@ export class MessagingAgent implements OnApplicationBootstrap {
     }
 
     if (newBpiMessageCandidate.isTransactionMessage()) {
-      // TODO: Perform additional transaction specific validation once #669 is done
+      if (!validate(newBpiMessageCandidate.fromBpiSubjectAccountId)) {
+        errors.push(
+          `fromBpiSubjectAccountId: ${newBpiMessageCandidate.fromBpiSubjectAccountId} is not valid UUID`,
+        );
+      }
+
+      if (!validate(newBpiMessageCandidate.toBpiSubjectAccountId)) {
+        errors.push(
+          `toBpiSubjectAccountId: ${newBpiMessageCandidate.toBpiSubjectAccountId} is not valid UUID`,
+        );
+      }
+
+      if (!validate(newBpiMessageCandidate.workflowId)) {
+        errors.push(
+          `workflowId: ${newBpiMessageCandidate.workflowId} is not valid UUID`,
+        );
+      }
+
+      if (!validate(newBpiMessageCandidate.workstepId)) {
+        errors.push(
+          `workstepId: ${newBpiMessageCandidate.workstepId} is not valid UUID`,
+        );
+      }
     }
 
     return [newBpiMessageCandidate, errors];

--- a/examples/bri-3/src/bri/communication/models/bpiMessage.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessage.ts
@@ -66,6 +66,22 @@ export class BpiMessage {
     this.signature = newSignature;
   }
 
+  public updateFromBpiSubjectAccountId(id: string): void {
+    this.fromBpiSubjectAccountId = id;
+  }
+
+  public updateToBpiSubjectAccountId(id: string): void {
+    this.toBpiSubjectAccountId = id;
+  }
+
+  public updateWorkflowId(id: string): void {
+    this.workflowId = id;
+  }
+
+  public updateWorkstepId(id: string): void {
+    this.workstepId = id;
+  }
+
   public isInfoMessage(): boolean {
     return this.type === BpiMessageType.Info;
   }

--- a/examples/bri-3/src/bri/communication/models/bpiMessage.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessage.ts
@@ -19,6 +19,15 @@ export class BpiMessage {
   toBpiSubjectId: string;
 
   @AutoMap()
+  fromBpiSubjectAccountId: string;
+
+  @AutoMap()
+  toBpiSubjectAccountId: string;
+
+  @AutoMap()
+  workstepId: string;
+
+  @AutoMap()
   content: string;
 
   @AutoMap()

--- a/examples/bri-3/src/bri/communication/models/bpiMessage.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessage.ts
@@ -25,6 +25,9 @@ export class BpiMessage {
   toBpiSubjectAccountId: string;
 
   @AutoMap()
+  workflowId: string;
+
+  @AutoMap()
   workstepId: string;
 
   @AutoMap()

--- a/examples/bri-3/src/bri/communication/models/bpiMessage.ts
+++ b/examples/bri-3/src/bri/communication/models/bpiMessage.ts
@@ -28,6 +28,9 @@ export class BpiMessage {
   workstepId: string;
 
   @AutoMap()
+  nonce: number;
+
+  @AutoMap()
   content: string;
 
   @AutoMap()

--- a/examples/bri-3/src/bri/identity/bpiAccounts/capabilities/createBpiAccount/createBpiAccountCommand.handler.ts
+++ b/examples/bri-3/src/bri/identity/bpiAccounts/capabilities/createBpiAccount/createBpiAccountCommand.handler.ts
@@ -20,16 +20,16 @@ export class CreateBpiAccountCommandHandler
         command.ownerBpiSubjectAccountsIds,
       );
 
-    const newBpiSubjectCandidate = this.accountAgent.createNewBpiAccount(
+    const newBpiAccountCandidate = this.accountAgent.createNewBpiAccount(
       ownerBpiSubjectAccounts,
       'sample authorization condition',
       'sample state object prover system',
       'sample state object storage',
     );
 
-    const newBpiSubject = await this.accountStorageAgent.storeNewBpiAccount(
-      newBpiSubjectCandidate,
+    const newBpiAccount = await this.accountStorageAgent.storeNewBpiAccount(
+      newBpiAccountCandidate,
     );
-    return newBpiSubject.id;
+    return newBpiAccount.id;
   }
 }

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount.ts
@@ -6,19 +6,19 @@ export class BpiSubjectAccount {
   id: string; // TODO: Add uuid after #491
 
   //Placeholder
-  @AutoMap(() => BpiSubject)
+  @AutoMap()
   authenticationPolicy: string;
 
   //Placeholder
-  @AutoMap(() => BpiSubject)
+  @AutoMap()
   authorizationPolicy: string;
 
   //Placeholder
-  @AutoMap(() => BpiSubject)
+  @AutoMap()
   verifiableCredential: string;
 
   //Placeholder
-  @AutoMap(() => BpiSubject)
+  @AutoMap()
   recoveryKey: string;
 
   @AutoMap(() => BpiSubject)

--- a/examples/bri-3/src/bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount.ts
+++ b/examples/bri-3/src/bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount.ts
@@ -37,7 +37,7 @@ export class BpiSubjectAccount {
     id: string,
     creatorBpiSubject: BpiSubject,
     ownerBpiSubject: BpiSubject,
-    authenticationPoliy: string,
+    authenticationPolicy: string,
     authorizationPolicy: string,
     verifiableCredential: string,
     recoveryKey: string,
@@ -47,7 +47,7 @@ export class BpiSubjectAccount {
     this.creatorBpiSubjectId = creatorBpiSubject?.id;
     this.ownerBpiSubject = ownerBpiSubject;
     this.ownerBpiSubjectId = ownerBpiSubject?.id;
-    this.authenticationPolicy = authenticationPoliy;
+    this.authenticationPolicy = authenticationPolicy;
     this.authorizationPolicy = authorizationPolicy;
     this.verifiableCredential = verifiableCredential;
     this.recoveryKey = recoveryKey;

--- a/examples/bri-3/src/bri/merkleTree/services/merkleTree.service.ts
+++ b/examples/bri-3/src/bri/merkleTree/services/merkleTree.service.ts
@@ -22,12 +22,12 @@ export class MerkleTreeService {
 
   public merkelizePayload(payload: JSON, hashAlgName: string): MerkleTree {
     const leaves: string[] = [];
-    const recurse = (payload: JSON, _currentKey: string) => {
+    const recurse = (payload: JSON) => {
       for (const key in payload) {
         const value = payload[key];
         if (value != undefined) {
           if (value && typeof value === 'object') {
-            recurse(value, key);
+            recurse(value);
           } else {
             leaves.push(key);
             leaves.push(value.toString());
@@ -36,7 +36,7 @@ export class MerkleTreeService {
       }
     };
 
-    recurse(payload, null);
+    recurse(payload);
     return this.formMerkleTree(leaves, hashAlgName);
   }
 }

--- a/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
+++ b/examples/bri-3/src/bri/transactions/agents/transactions.agent.ts
@@ -141,10 +141,9 @@ export class TransactionAgent {
       return false;
     }
 
-    // TODO: #668 - Uncomment this check once workflow has bpiAccount reference
-    // if (tx.nonce !== workflow.bpiAccount.nonce + 1) {
-    //   return false;
-    // }
+    if (tx.nonce !== workflow.bpiAccount.nonce + 1) {
+      return false;
+    }
 
     const isSignatureValid = this.authAgent.verifySignatureAgainstPublicKey(
       tx.payload,

--- a/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
@@ -35,7 +35,7 @@ export class WorkflowAgent {
     name: string,
     worksteps: Workstep[],
     workgroupId: string,
-    bpiAccount: BpiAccount
+    bpiAccount: BpiAccount,
   ): Workflow {
     return new Workflow(uuidv4(), name, worksteps, workgroupId, bpiAccount);
   }

--- a/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
@@ -1,9 +1,16 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { BpiAccount } from '../../../identity/bpiAccounts/models/bpiAccount';
+import { BpiSubjectAccount } from '../../../identity/bpiSubjectAccounts/models/bpiSubjectAccount';
+import { BpiSubject } from '../../../identity/bpiSubjects/models/bpiSubject';
 import { WorkstepStorageAgent } from '../../worksteps/agents/workstepsStorage.agent';
 import { Workstep } from '../../worksteps/models/workstep';
 import {
+  BPI_ACCOUNT_OWNERS_NOT_WORKGROUP_PARTICIPANTS,
   WORKFLOW_NOT_FOUND_ERR_MESSAGE,
   WORKSTEP_NOT_FOUND_ERR_MESSAGE,
 } from '../api/err.messages';
@@ -38,6 +45,27 @@ export class WorkflowAgent {
     bpiAccount: BpiAccount,
   ): Workflow {
     return new Workflow(uuidv4(), name, worksteps, workgroupId, bpiAccount);
+  }
+
+  public async throwIfWorkflowBpiAccountOwnersAreNotWorkgroupParticipants(
+    workgroupParticipants: BpiSubject[],
+    bpiAccountOwnerCandidates: BpiSubjectAccount[],
+  ): Promise<boolean> {
+    bpiAccountOwnerCandidates.forEach((bpiSubjectAccount) => {
+      const ownerIndexInListOfParticipants = workgroupParticipants.findIndex(
+        (bpiSubject) => {
+          bpiSubject.id === bpiSubjectAccount.ownerBpiSubjectId;
+        },
+      );
+
+      if (ownerIndexInListOfParticipants === -1) {
+        throw new BadRequestException(
+          BPI_ACCOUNT_OWNERS_NOT_WORKGROUP_PARTICIPANTS,
+        );
+      }
+    });
+
+    return true;
   }
 
   public async fetchUpdateCandidateAndThrowIfUpdateValidationFails(

--- a/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
@@ -1,13 +1,14 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Workstep } from '../../worksteps/models/workstep';
-import { Workflow } from '../models/workflow';
 import { v4 as uuidv4 } from 'uuid';
+import { BpiAccount } from '../../../identity/bpiAccounts/models/bpiAccount';
+import { WorkstepStorageAgent } from '../../worksteps/agents/workstepsStorage.agent';
+import { Workstep } from '../../worksteps/models/workstep';
 import {
   WORKFLOW_NOT_FOUND_ERR_MESSAGE,
   WORKSTEP_NOT_FOUND_ERR_MESSAGE,
 } from '../api/err.messages';
+import { Workflow } from '../models/workflow';
 import { WorkflowStorageAgent } from './workflowsStorage.agent';
-import { WorkstepStorageAgent } from '../../worksteps/agents/workstepsStorage.agent';
 
 @Injectable()
 export class WorkflowAgent {
@@ -34,8 +35,9 @@ export class WorkflowAgent {
     name: string,
     worksteps: Workstep[],
     workgroupId: string,
+    bpiAccount: BpiAccount
   ): Workflow {
-    return new Workflow(uuidv4(), name, worksteps, workgroupId);
+    return new Workflow(uuidv4(), name, worksteps, workgroupId, bpiAccount);
   }
 
   public async fetchUpdateCandidateAndThrowIfUpdateValidationFails(

--- a/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/agents/workflows.agent.ts
@@ -54,7 +54,7 @@ export class WorkflowAgent {
     bpiAccountOwnerCandidates.forEach((bpiSubjectAccount) => {
       const ownerIndexInListOfParticipants = workgroupParticipants.findIndex(
         (bpiSubject) => {
-          bpiSubject.id === bpiSubjectAccount.ownerBpiSubjectId;
+          return bpiSubject.id === bpiSubjectAccount.ownerBpiSubjectId;
         },
       );
 

--- a/examples/bri-3/src/bri/workgroup/workflows/agents/workflowsStorage.agent.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/agents/workflowsStorage.agent.ts
@@ -60,6 +60,7 @@ export class WorkflowStorageAgent extends PrismaService {
           connect: workstepIds,
         },
         workgroupId: workflow.workgroupId,
+        bpiAccountId: workflow.bpiAccountId,
       },
       include: {
         worksteps: true,

--- a/examples/bri-3/src/bri/workgroup/workflows/api/dtos/request/createWorkflow.dto.spec.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/dtos/request/createWorkflow.dto.spec.ts
@@ -5,7 +5,11 @@ import { CreateWorkflowDto } from './createWorkflow.dto';
 describe('CreateWorkflowDto', () => {
   it('should return error in case name not provided.', async () => {
     // Arrange
-    const dto = { workstepIds: ['1'], workgroupId: '1' };
+    const dto = {
+      workstepIds: ['1'],
+      workgroupId: '1',
+      workflowBpiAccountSubjectAccountOwnersIds: ['1'],
+    };
     const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
 
     // Act
@@ -21,7 +25,11 @@ describe('CreateWorkflowDto', () => {
 
   it('should return error in case workgroupId not provided.', async () => {
     // Arrange
-    const dto = { name: 'test', workstepIds: ['1'] };
+    const dto = {
+      name: 'test',
+      workstepIds: ['1'],
+      workflowBpiAccountSubjectAccountOwnersIds: ['1'],
+    };
     const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
 
     // Act
@@ -37,7 +45,11 @@ describe('CreateWorkflowDto', () => {
 
   it('should return error in case workstepIds not provided.', async () => {
     // Arrange
-    const dto = { name: 'test', workgroupId: '1' };
+    const dto = {
+      name: 'test',
+      workgroupId: '1',
+      workflowBpiAccountSubjectAccountOwnersIds: ['1'],
+    };
     const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
 
     // Act
@@ -53,7 +65,12 @@ describe('CreateWorkflowDto', () => {
 
   it('should return error in case an empty workstepIds array is provided.', async () => {
     // Arrange
-    const dto = { name: 'test', workstepIds: [], workgroupId: '1' };
+    const dto = {
+      name: 'test',
+      workstepIds: [],
+      workgroupId: '1',
+      workflowBpiAccountSubjectAccountOwnersIds: ['1'],
+    };
     const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
 
     // Act
@@ -67,9 +84,55 @@ describe('CreateWorkflowDto', () => {
     );
   });
 
-  it('should return no error if all required properties provided.', async () => {
+  it('should return error in case workflowBpiAccountSubjectAccountOwnersIds not provided.', async () => {
     // Arrange
     const dto = { name: 'test', workstepIds: ['1'], workgroupId: '1' };
+    const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
+
+    // Act
+    const errors = await validate(createWorkflowDto);
+
+    // Assert
+    expect(errors.length).toBe(1);
+    expect(errors[0].property).toEqual(
+      'workflowBpiAccountSubjectAccountOwnersIds',
+    );
+    expect(errors[0].constraints?.isNotEmpty).toContain(
+      'workflowBpiAccountSubjectAccountOwnersIds should not be empty',
+    );
+  });
+
+  it('should return error in case an empty workflowBpiAccountSubjectAccountOwnersIds array is provided.', async () => {
+    // Arrange
+    const dto = {
+      name: 'test',
+      workstepIds: ['1'],
+      workgroupId: '1',
+      workflowBpiAccountSubjectAccountOwnersIds: [],
+    };
+    const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
+
+    // Act
+    const errors = await validate(createWorkflowDto);
+
+    // Assert
+    expect(errors.length).toBe(1);
+    expect(errors[0].property).toEqual(
+      'workflowBpiAccountSubjectAccountOwnersIds',
+    );
+    expect(errors[0].constraints?.arrayNotEmpty).toContain(
+      'workflowBpiAccountSubjectAccountOwnersIds should not be empty',
+    );
+  });
+
+  it('should return no error if all required properties provided.', async () => {
+    // Arrange
+    const dto = {
+      name: 'test',
+      workstepIds: ['1'],
+      workgroupId: '1',
+      workflowBpiAccountSubjectAccountOwnersIds: ['1'],
+    };
     const createWorkflowDto = plainToInstance(CreateWorkflowDto, dto);
 
     // Act

--- a/examples/bri-3/src/bri/workgroup/workflows/api/dtos/request/createWorkflow.dto.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/dtos/request/createWorkflow.dto.ts
@@ -10,4 +10,8 @@ export class CreateWorkflowDto {
 
   @IsNotEmpty()
   workgroupId: string;
+
+  @IsNotEmpty()
+  @ArrayNotEmpty()
+  workflowBpiAccountSubjectAccountOwnersIds: string[];
 }

--- a/examples/bri-3/src/bri/workgroup/workflows/api/err.messages.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/err.messages.ts
@@ -1,3 +1,6 @@
 export const WORKFLOW_NOT_FOUND_ERR_MESSAGE = 'Workflow does not exist.';
 
 export const WORKSTEP_NOT_FOUND_ERR_MESSAGE = 'Workstep does not exist.';
+
+export const BPI_ACCOUNT_OWNERS_NOT_WORKGROUP_PARTICIPANTS =
+  'Provided Bpi Subject Account owners are not Workgroup participants.';

--- a/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.spec.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.spec.ts
@@ -33,6 +33,7 @@ describe('WorkflowsController', () => {
   let workflowStorageAgentMock: DeepMockProxy<WorkflowStorageAgent>;
   let workgroupAgentMock: DeepMockProxy<WorkgroupAgent>;
   let bpiSubjectAccountAgentMock: DeepMockProxy<BpiSubjectAccountAgent>;
+  let bpiAccountStorageAgentMock: DeepMockProxy<BpiAccountStorageAgent>;
 
   // TODO: Setup of this test data below is what should be handled in a separate file where we mock only prisma.client
   // and implement various test data scenarios that can be selected with a single line of code.
@@ -125,6 +126,7 @@ describe('WorkflowsController', () => {
     workflowStorageAgentMock = app.get(WorkflowStorageAgent);
     workgroupAgentMock = app.get(WorkgroupAgent);
     bpiSubjectAccountAgentMock = app.get(BpiSubjectAccountAgent);
+    bpiAccountStorageAgentMock = app.get(BpiAccountStorageAgent);
 
     await app.init();
   });
@@ -210,6 +212,10 @@ describe('WorkflowsController', () => {
 
       bpiSubjectAccountAgentMock.getBpiSubjectAccountsAndThrowIfNotExist.mockResolvedValueOnce(
         [existingBpiSubjectAccount1, existingBpiSubjectAccount2],
+      );
+
+      bpiAccountStorageAgentMock.storeNewBpiAccount.mockResolvedValueOnce(
+        existingBpiAccount1,
       );
 
       const requestDto = {

--- a/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.spec.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.spec.ts
@@ -36,6 +36,7 @@ describe('WorkflowsController', () => {
   let bpiSubjectAccountAgentMock: DeepMockProxy<BpiSubjectAccountAgent>;
 
   beforeEach(async () => {
+    const 
     const app: TestingModule = await Test.createTestingModule({
       imports: [
         CqrsModule,

--- a/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.spec.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.spec.ts
@@ -34,6 +34,8 @@ describe('WorkflowsController', () => {
   let workgroupAgentMock: DeepMockProxy<WorkgroupAgent>;
   let bpiSubjectAccountAgentMock: DeepMockProxy<BpiSubjectAccountAgent>;
 
+  // TODO: Setup of this test data below is what should be handled in a separate file where we mock only prisma.client
+  // and implement various test data scenarios that can be selected with a single line of code.
   let existingWorkgroupId;
   let existingBpiSubject1;
   let existingBpiSubject2;

--- a/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/api/workflows.controller.ts
@@ -42,6 +42,7 @@ export class WorkflowController {
         requestDto.name,
         requestDto.workgroupId,
         requestDto.workstepIds,
+        requestDto.workflowBpiAccountSubjectAccountOwnersIds,
       ),
     );
   }

--- a/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflow.command.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflow.command.ts
@@ -3,5 +3,6 @@ export class CreateWorkflowCommand {
     public readonly name: string,
     public readonly workgroupId: string,
     public readonly workstepIds: string[],
+    public readonly workflowBpiAccountSubjectAccountOwnersIds: string[],
   ) {}
 }

--- a/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflowCommand.handler.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflowCommand.handler.ts
@@ -2,6 +2,9 @@ import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import { WorkflowAgent } from '../../agents/workflows.agent';
 import { WorkflowStorageAgent } from '../../agents/workflowsStorage.agent';
 import { CreateWorkflowCommand } from './createWorkflow.command';
+import { BpiAccountAgent } from 'src/bri/identity/bpiAccounts/agents/bpiAccounts.agent';
+import { BpiAccountStorageAgent } from 'src/bri/identity/bpiAccounts/agents/bpiAccountsStorage.agent';
+import { WorkgroupStorageAgent } from 'src/bri/workgroup/workgroups/agents/workgroupStorage.agent';
 
 @CommandHandler(CreateWorkflowCommand)
 export class CreateWorkflowCommandHandler
@@ -9,7 +12,10 @@ export class CreateWorkflowCommandHandler
 {
   constructor(
     private agent: WorkflowAgent,
+    private accountAgent: BpiAccountAgent,
     private storageAgent: WorkflowStorageAgent,
+    private workgroupStorageAgent: WorkgroupStorageAgent,
+    private accountStorageAgent: BpiAccountStorageAgent,
   ) {}
 
   async execute(command: CreateWorkflowCommand) {
@@ -18,10 +24,25 @@ export class CreateWorkflowCommandHandler
         command.workstepIds,
       );
 
+    const workgroup = await this.workgroupStorageAgent.getWorkgroupById(command.workgroupId);
+    
+    
+    const newBpiAccountCandidate = this.accountAgent.createNewBpiAccount(
+       [], // TODO:  workgroup.participants, either get all BpiSubjectAccounts bellonging to participatns or have bpisubjectaccounts ids passed as param
+       'sample authorization condition',
+       'sample state object prover system',
+       'sample state object storage',
+    );
+  
+    const newBpiAccount = await this.accountStorageAgent.storeNewBpiAccount(
+      newBpiAccountCandidate,
+    );
+
     const newWorkflowCandidate = this.agent.createNewWorkflow(
       command.name,
       workstepsToConnect,
       command.workgroupId,
+      newBpiAccount
     );
 
     const newWorkflow = await this.storageAgent.storeNewWorkflow(

--- a/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflowCommand.handler.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflowCommand.handler.ts
@@ -24,16 +24,17 @@ export class CreateWorkflowCommandHandler
         command.workstepIds,
       );
 
-    const workgroup = await this.workgroupStorageAgent.getWorkgroupById(command.workgroupId);
-    
-    
-    const newBpiAccountCandidate = this.accountAgent.createNewBpiAccount(
-       [], // TODO:  workgroup.participants, either get all BpiSubjectAccounts bellonging to participatns or have bpisubjectaccounts ids passed as param
-       'sample authorization condition',
-       'sample state object prover system',
-       'sample state object storage',
+    const workgroup = await this.workgroupStorageAgent.getWorkgroupById(
+      command.workgroupId,
     );
-  
+
+    const newBpiAccountCandidate = this.accountAgent.createNewBpiAccount(
+      [], // TODO:  workgroup.participants, either get all BpiSubjectAccounts bellonging to participatns or have bpisubjectaccounts ids passed as param
+      'sample authorization condition',
+      'sample state object prover system',
+      'sample state object storage',
+    );
+
     const newBpiAccount = await this.accountStorageAgent.storeNewBpiAccount(
       newBpiAccountCandidate,
     );
@@ -42,7 +43,7 @@ export class CreateWorkflowCommandHandler
       command.name,
       workstepsToConnect,
       command.workgroupId,
-      newBpiAccount
+      newBpiAccount,
     );
 
     const newWorkflow = await this.storageAgent.storeNewWorkflow(

--- a/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
@@ -1,5 +1,6 @@
 import { AutoMap } from '@automapper/classes';
 import { BpiAccount } from '../../../identity/bpiAccounts/models/bpiAccount';
+import { Workgroup } from '../../workgroups/models/workgroup';
 import { Workstep } from '../../worksteps/models/workstep';
 
 export class Workflow {
@@ -14,6 +15,9 @@ export class Workflow {
 
   @AutoMap()
   workgroupId: string;
+
+  @AutoMap()
+  workgroup: Workgroup;
 
   @AutoMap()
   bpiAccountId: string;
@@ -32,6 +36,7 @@ export class Workflow {
     this.name = name;
     this.worksteps = worksteps;
     this.workgroupId = workgroupId;
+    this.bpiAccountId = bpiAccount.id;
     this.bpiAccount = bpiAccount;
   }
 

--- a/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
@@ -15,6 +15,9 @@ export class Workflow {
   @AutoMap()
   workgroupId: string;
 
+  @AutoMap()
+  bpiAccountId: string;
+
   @AutoMap(() => BpiAccount)
   bpiAccount: BpiAccount;
 

--- a/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
@@ -23,7 +23,7 @@ export class Workflow {
     name: string,
     worksteps: Workstep[],
     workgroupId: string,
-    bpiAccount: BpiAccount
+    bpiAccount: BpiAccount,
   ) {
     this.id = id;
     this.name = name;

--- a/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/models/workflow.ts
@@ -1,4 +1,5 @@
 import { AutoMap } from '@automapper/classes';
+import { BpiAccount } from '../../../identity/bpiAccounts/models/bpiAccount';
 import { Workstep } from '../../worksteps/models/workstep';
 
 export class Workflow {
@@ -14,16 +15,21 @@ export class Workflow {
   @AutoMap()
   workgroupId: string;
 
+  @AutoMap(() => BpiAccount)
+  bpiAccount: BpiAccount;
+
   constructor(
     id: string,
     name: string,
     worksteps: Workstep[],
     workgroupId: string,
+    bpiAccount: BpiAccount
   ) {
     this.id = id;
     this.name = name;
     this.worksteps = worksteps;
     this.workgroupId = workgroupId;
+    this.bpiAccount = bpiAccount;
   }
 
   public updateName(newName: string): void {

--- a/examples/bri-3/src/bri/workgroup/workgroups/agents/workgroupStorage.agent.ts
+++ b/examples/bri-3/src/bri/workgroup/workgroups/agents/workgroupStorage.agent.ts
@@ -19,7 +19,7 @@ export class WorkgroupStorageAgent extends PrismaService {
         administrators: true,
         participants: true,
         workflows: {
-          include: { worksteps: true },
+          include: { worksteps: true, bpiAccount: true },
         },
       },
     });
@@ -62,7 +62,7 @@ export class WorkgroupStorageAgent extends PrismaService {
         administrators: true,
         participants: true,
         workflows: {
-          include: { worksteps: true },
+          include: { worksteps: true, bpiAccount: true },
         },
       },
     });
@@ -100,7 +100,7 @@ export class WorkgroupStorageAgent extends PrismaService {
         administrators: true,
         participants: true,
         workflows: {
-          include: { worksteps: true },
+          include: { worksteps: true, bpiAccount: true },
         },
       },
     });

--- a/examples/bri-3/src/bri/zeroKnowledgeProof/services/circuit/circuit.interface.ts
+++ b/examples/bri-3/src/bri/zeroKnowledgeProof/services/circuit/circuit.interface.ts
@@ -4,7 +4,7 @@ import { Witness } from '../../models/witness';
 export interface ICircuitService {
   witness: Witness;
   createWitness(input: object): Promise<Witness>;
-  createProof(witness: Witness): Promise<Proof>
+  createProof(witness: Witness): Promise<Proof>;
   verifyProof(proof: Proof, witness: Witness): Promise<boolean>;
   verifyProofUsingWitness(witness: Witness): Promise<boolean>;
 }

--- a/examples/bri-3/src/bri/zeroKnowledgeProof/services/circuit/circuit.interface.ts
+++ b/examples/bri-3/src/bri/zeroKnowledgeProof/services/circuit/circuit.interface.ts
@@ -1,7 +1,10 @@
+import { Proof } from '../../models/proof';
 import { Witness } from '../../models/witness';
 
 export interface ICircuitService {
   witness: Witness;
   createWitness(input: object): Promise<Witness>;
+  createProof(witness: Witness): Promise<Proof>
+  verifyProof(proof: Proof, witness: Witness): Promise<boolean>;
   verifyProofUsingWitness(witness: Witness): Promise<boolean>;
 }

--- a/examples/bri-3/src/bri/zeroKnowledgeProof/services/circuit/snarkjs/snarkjs.service.ts
+++ b/examples/bri-3/src/bri/zeroKnowledgeProof/services/circuit/snarkjs/snarkjs.service.ts
@@ -3,7 +3,9 @@ import { Witness } from '../../../models/witness';
 import { Proof } from '../../../models/proof';
 import { ICircuitService } from '../circuit.interface';
 import * as snarkjs from 'snarkjs';
-import * as verificationKey from '../../../../../../zeroKnowledgeKeys/circuit/circuit_verification_key.json';
+// TODO: Does not compile atm because the circuit_verification_key.json does not exist
+// Probably has to be dynamically loaded
+// import * as verificationKey from '../../../../../../zeroKnowledgeKeys/circuit/circuit_verification_key.json';
 import 'dotenv/config';
 
 @Injectable()
@@ -19,8 +21,16 @@ export class SnarkjsCircuitService implements ICircuitService {
 
     this.witness.publicInputs = publicInputs;
 
-    this.witness.verificationKey = verificationKey;
+    // TODO: Above TODO
+    // this.witness.verificationKey = verificationKey;
     return this.witness;
+  }
+
+  createProof(witness: Witness): Promise<Proof> {
+    throw new Error('Method not implemented.');
+  }
+  verifyProof(proof: Proof, witness: Witness): Promise<boolean> {
+    throw new Error('Method not implemented.');
   }
 
   public async verifyProofUsingWitness(witness: Witness): Promise<boolean> {

--- a/examples/bri-3/src/shared/testing/builders.ts
+++ b/examples/bri-3/src/shared/testing/builders.ts
@@ -1,0 +1,297 @@
+import { BpiAccount } from 'src/bri/identity/bpiAccounts/models/bpiAccount';
+import { BpiSubjectAccount } from 'src/bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount';
+import { BpiSubject } from 'src/bri/identity/bpiSubjects/models/bpiSubject';
+import { BpiSubjectRole } from 'src/bri/identity/bpiSubjects/models/bpiSubjectRole';
+import { Workflow } from 'src/bri/workgroup/workflows/models/workflow';
+import { Workgroup } from 'src/bri/workgroup/workgroups/models/workgroup';
+import { Workstep } from 'src/bri/workgroup/worksteps/models/workstep';
+
+export class WorkstepBuilder {
+  private id: string;
+  private name: string;
+  private version: string;
+  private status: string;
+  private workgroupId: string;
+  private securityPolicy: string;
+  private privacyPolicy: string;
+
+  constructor() {}
+
+  setId(id: string): WorkstepBuilder {
+    this.id = id;
+    return this;
+  }
+
+  setName(name: string): WorkstepBuilder {
+    this.name = name;
+    return this;
+  }
+
+  setVersion(version: string): WorkstepBuilder {
+    this.version = version;
+    return this;
+  }
+
+  setStatus(status: string): WorkstepBuilder {
+    this.status = status;
+    return this;
+  }
+
+  setWorkgroupId(workgroupId: string): WorkstepBuilder {
+    this.workgroupId = workgroupId;
+    return this;
+  }
+
+  setSecurityPolicy(securityPolicy: string): WorkstepBuilder {
+    this.securityPolicy = securityPolicy;
+    return this;
+  }
+
+  setPrivacyPolicy(privacyPolicy: string): WorkstepBuilder {
+    this.privacyPolicy = privacyPolicy;
+    return this;
+  }
+
+  build(): Workstep {
+    return new Workstep(
+      this.id,
+      this.name,
+      this.version,
+      this.status,
+      this.workgroupId,
+      this.securityPolicy,
+      this.privacyPolicy,
+    );
+  }
+}
+
+export class WorkflowBuilder {
+  private id: string;
+  private name: string;
+  private worksteps: Workstep[];
+  private workgroupId: string;
+  private bpiAccount: BpiAccount;
+
+  constructor() {}
+
+  setId(id: string): WorkflowBuilder {
+    this.id = id;
+    return this;
+  }
+
+  setName(name: string): WorkflowBuilder {
+    this.name = name;
+    return this;
+  }
+
+  setWorksteps(worksteps: Workstep[]): WorkflowBuilder {
+    this.worksteps = worksteps;
+    return this;
+  }
+
+  setWorkgroupId(workgroupId: string): WorkflowBuilder {
+    this.workgroupId = workgroupId;
+    return this;
+  }
+
+  setBpiAccount(bpiAccount: BpiAccount): WorkflowBuilder {
+    this.bpiAccount = bpiAccount;
+    return this;
+  }
+
+  build(): Workflow {
+    return new Workflow(
+      this.id,
+      this.name,
+      this.worksteps,
+      this.workgroupId,
+      this.bpiAccount,
+    );
+  }
+}
+
+export class BpiSubjectBuilder {
+  private id: string;
+  private name: string;
+  private description: string;
+  private publicKey: string;
+  private loginNonce: string;
+  private roles: BpiSubjectRole[];
+
+  constructor() {}
+
+  setId(id: string): BpiSubjectBuilder {
+    this.id = id;
+    return this;
+  }
+
+  setName(name: string): BpiSubjectBuilder {
+    this.name = name;
+    return this;
+  }
+
+  setDescription(description: string): BpiSubjectBuilder {
+    this.description = description;
+    return this;
+  }
+
+  setPublicKey(publicKey: string): BpiSubjectBuilder {
+    this.publicKey = publicKey;
+    return this;
+  }
+
+  setLoginNonce(loginNonce: string): BpiSubjectBuilder {
+    this.loginNonce = loginNonce;
+    return this;
+  }
+
+  setRoles(roles: BpiSubjectRole[]): BpiSubjectBuilder {
+    this.roles = roles;
+    return this;
+  }
+
+  build(): BpiSubject {
+    return new BpiSubject(
+      this.id,
+      this.name,
+      this.description,
+      this.publicKey,
+      this.roles,
+    );
+  }
+}
+
+export class WorkgroupBuilder {
+  private id: string;
+  private name: string;
+  private administrators: BpiSubject[] = [];
+  private securityPolicy: string;
+  private privacyPolicy: string;
+  private participants: BpiSubject[] = [];
+  private worksteps: Workstep[] = [];
+  private workflows: Workflow[] = [];
+
+  constructor() {}
+
+  setId(id: string): WorkgroupBuilder {
+    this.id = id;
+    return this;
+  }
+
+  setName(name: string): WorkgroupBuilder {
+    this.name = name;
+    return this;
+  }
+
+  setAdministrators(administrators: BpiSubject[]): WorkgroupBuilder {
+    this.administrators = administrators;
+    return this;
+  }
+
+  setSecurityPolicy(securityPolicy: string): WorkgroupBuilder {
+    this.securityPolicy = securityPolicy;
+    return this;
+  }
+
+  setPrivacyPolicy(privacyPolicy: string): WorkgroupBuilder {
+    this.privacyPolicy = privacyPolicy;
+    return this;
+  }
+
+  setParticipants(participants: BpiSubject[]): WorkgroupBuilder {
+    this.participants = participants;
+    return this;
+  }
+
+  setWorksteps(worksteps: Workstep[]): WorkgroupBuilder {
+    this.worksteps = worksteps;
+    return this;
+  }
+
+  setWorkflows(workflows: Workflow[]): WorkgroupBuilder {
+    this.workflows = workflows;
+    return this;
+  }
+
+  public build(): Workgroup {
+    const workgroup = new Workgroup(
+      this.id,
+      this.name,
+      this.administrators,
+      this.securityPolicy,
+      this.privacyPolicy,
+      this.participants,
+      this.worksteps,
+      this.workflows,
+    );
+    return workgroup;
+  }
+}
+
+export class BpiSubjectAccountBuilder {
+  private id: string;
+  private authenticationPolicy?: string;
+  private authorizationPolicy?: string;
+  private verifiableCredential?: string;
+  private recoveryKey?: string;
+  private creatorBpiSubject: BpiSubject;
+  private ownerBpiSubject: BpiSubject;
+
+  constructor() {}
+
+  setId(id: string): BpiSubjectAccountBuilder {
+    this.id = id;
+    return this;
+  }
+
+  setCreatorBpiSubject(
+    creatorBpiSubject: BpiSubject,
+  ): BpiSubjectAccountBuilder {
+    this.creatorBpiSubject = creatorBpiSubject;
+    return this;
+  }
+
+  setOwnerBpiSubject(ownerBpiSubject: BpiSubject): BpiSubjectAccountBuilder {
+    this.ownerBpiSubject = ownerBpiSubject;
+    return this;
+  }
+
+  setAuthenticationPolicy(
+    authenticationPolicy: string,
+  ): BpiSubjectAccountBuilder {
+    this.authenticationPolicy = authenticationPolicy;
+    return this;
+  }
+
+  setAuthorizationPolicy(
+    authorizationPolicy: string,
+  ): BpiSubjectAccountBuilder {
+    this.authorizationPolicy = authorizationPolicy;
+    return this;
+  }
+
+  setVerifiableCredential(
+    verifiableCredential: string,
+  ): BpiSubjectAccountBuilder {
+    this.verifiableCredential = verifiableCredential;
+    return this;
+  }
+
+  setRecoveryKey(recoveryKey: string): BpiSubjectAccountBuilder {
+    this.recoveryKey = recoveryKey;
+    return this;
+  }
+
+  public build(): BpiSubjectAccount {
+    const bpiSubjectAccount = new BpiSubjectAccount(
+      this.id,
+      this.creatorBpiSubject,
+      this.ownerBpiSubject,
+      this.authenticationPolicy ?? '',
+      this.authorizationPolicy ?? '',
+      this.verifiableCredential ?? '',
+      this.recoveryKey ?? '',
+    );
+    return bpiSubjectAccount;
+  }
+}

--- a/examples/bri-3/src/shared/testing/builders.ts
+++ b/examples/bri-3/src/shared/testing/builders.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 import { BpiAccount } from '../../bri/identity/bpiAccounts/models/bpiAccount';
 import { BpiSubjectAccount } from '../../bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount';
 import { BpiSubject } from '../../bri/identity/bpiSubjects/models/bpiSubject';

--- a/examples/bri-3/src/shared/testing/builders.ts
+++ b/examples/bri-3/src/shared/testing/builders.ts
@@ -1,10 +1,10 @@
-import { BpiAccount } from 'src/bri/identity/bpiAccounts/models/bpiAccount';
-import { BpiSubjectAccount } from 'src/bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount';
-import { BpiSubject } from 'src/bri/identity/bpiSubjects/models/bpiSubject';
-import { BpiSubjectRole } from 'src/bri/identity/bpiSubjects/models/bpiSubjectRole';
-import { Workflow } from 'src/bri/workgroup/workflows/models/workflow';
-import { Workgroup } from 'src/bri/workgroup/workgroups/models/workgroup';
-import { Workstep } from 'src/bri/workgroup/worksteps/models/workstep';
+import { BpiAccount } from '../../bri/identity/bpiAccounts/models/bpiAccount';
+import { BpiSubjectAccount } from '../../bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount';
+import { BpiSubject } from '../../bri/identity/bpiSubjects/models/bpiSubject';
+import { BpiSubjectRole } from '../../bri/identity/bpiSubjects/models/bpiSubjectRole';
+import { Workflow } from '../../bri/workgroup/workflows/models/workflow';
+import { Workgroup } from '../../bri/workgroup/workgroups/models/workgroup';
+import { Workstep } from '../../bri/workgroup/worksteps/models/workstep';
 
 export class WorkstepBuilder {
   private id: string;

--- a/examples/bri-3/src/shared/testing/builders.ts
+++ b/examples/bri-3/src/shared/testing/builders.ts
@@ -295,3 +295,60 @@ export class BpiSubjectAccountBuilder {
     return bpiSubjectAccount;
   }
 }
+
+export class BpiAccountBuilder {
+  private id: string;
+  private nonce = 0;
+  private ownerBpiSubjectAccounts: BpiSubjectAccount[] = [];
+  private authorizationCondition: string;
+  private stateObjectProverSystem: string;
+  private stateObjectStorage: string;
+
+  constructor() {}
+
+  setId(id: string): BpiAccountBuilder {
+    this.id = id;
+    return this;
+  }
+
+  setNonce(nonce: number): BpiAccountBuilder {
+    this.nonce = nonce;
+    return this;
+  }
+
+  setOwnerBpiSubjectAccounts(
+    ownerBpiSubjectAccounts: BpiSubjectAccount[],
+  ): BpiAccountBuilder {
+    this.ownerBpiSubjectAccounts = ownerBpiSubjectAccounts;
+    return this;
+  }
+
+  setAuthorizationCondition(authorizationCondition: string): BpiAccountBuilder {
+    this.authorizationCondition = authorizationCondition;
+    return this;
+  }
+
+  setStateObjectProverSystem(
+    stateObjectProverSystem: string,
+  ): BpiAccountBuilder {
+    this.stateObjectProverSystem = stateObjectProverSystem;
+    return this;
+  }
+
+  setStateObjectStorage(stateObjectStorage: string): BpiAccountBuilder {
+    this.stateObjectStorage = stateObjectStorage;
+    return this;
+  }
+
+  public build(): BpiAccount {
+    const bpiAccount = new BpiAccount(
+      this.id,
+      this.ownerBpiSubjectAccounts,
+      this.authorizationCondition,
+      this.stateObjectProverSystem,
+      this.stateObjectStorage,
+    );
+    bpiAccount.nonce = this.nonce;
+    return bpiAccount;
+  }
+}

--- a/examples/bri-3/src/shared/testing/testData.helper.ts
+++ b/examples/bri-3/src/shared/testing/testData.helper.ts
@@ -1,0 +1,102 @@
+import { BpiAccount } from 'src/bri/identity/bpiAccounts/models/bpiAccount';
+import { BpiSubject } from 'src/bri/identity/bpiSubjects/models/bpiSubject';
+import {
+  BpiSubjectRole,
+  BpiSubjectRoleName,
+} from 'src/bri/identity/bpiSubjects/models/bpiSubjectRole';
+import { Workstep } from 'src/bri/workgroup/worksteps/models/workstep';
+import { uuid } from 'uuidv4';
+import {
+  BpiSubjectAccountBuilder,
+  BpiSubjectBuilder,
+  WorkflowBuilder,
+  WorkgroupBuilder,
+  WorkstepBuilder,
+} from './builders';
+import { Workflow } from 'src/bri/workgroup/workflows/models/workflow';
+
+// A place to encapsulate  creation of test data objects used for controller testing.
+// These objects will later be used to mock prisma.client calls only once during test bootstrap
+// (https://www.prisma.io/docs/guides/testing/unit-testing)
+// which will help avoid the need to mock all agents separately
+export class TestDataHelper {
+  public static createTestWorkstep = (workgroupId: string) => {
+    const workstep = new WorkstepBuilder()
+      .setId('123')
+      .setName('Example Workstep')
+      .setVersion('1.0')
+      .setStatus('Active')
+      .setWorkgroupId(workgroupId)
+      .build();
+
+    return workstep;
+  };
+
+  public static createTestWorkflow = (
+    worksteps: Workstep[],
+    bpiAccount: BpiAccount,
+  ) => {
+    const workflow = new WorkflowBuilder()
+      .setId('123')
+      .setName('Example Workflow')
+      .setWorksteps(worksteps)
+      .setWorkgroupId('456')
+      .setBpiAccount(bpiAccount)
+      .build();
+
+    return workflow;
+  };
+
+  public static createBpiSubject = () => {
+    const bpiSubject = new BpiSubjectBuilder()
+      .setId(uuid())
+      .setName('name')
+      .setDescription('desc')
+      .setPublicKey('pk')
+      .setRoles([
+        new BpiSubjectRole(
+          uuid(),
+          BpiSubjectRoleName.EXTERNAL_BPI_SUBJECT,
+          'desc',
+        ),
+      ])
+      .build();
+
+    return bpiSubject;
+  };
+
+  public static createWorkgroup = (
+    admins: BpiSubject[],
+    participants: BpiSubject[],
+    worksteps: Workstep[],
+    workflows: Workflow[],
+  ) => {
+    const workgroup = new WorkgroupBuilder()
+      .setAdministrators(admins)
+      .setSecurityPolicy('security policy')
+      .setPrivacyPolicy('privacy policy')
+      .setParticipants(participants)
+      .setWorksteps(worksteps)
+      .setWorkflows(workflows)
+      .build();
+
+    return workgroup;
+  };
+
+  public static createBpiSubjectAccount = (
+    owner: BpiSubject,
+    creator: BpiSubject,
+  ) => {
+    const bpiSubjectAccount = new BpiSubjectAccountBuilder()
+      .setId(uuid())
+      .setOwnerBpiSubject(owner)
+      .setCreatorBpiSubject(creator)
+      .setAuthenticationPolicy('authentication policy')
+      .setAuthorizationPolicy('authorization policy')
+      .setVerifiableCredential('verifiable credential')
+      .setRecoveryKey('recovery key')
+      .build();
+
+    return bpiSubjectAccount;
+  };
+}

--- a/examples/bri-3/src/shared/testing/testData.helper.ts
+++ b/examples/bri-3/src/shared/testing/testData.helper.ts
@@ -1,11 +1,12 @@
-import { BpiAccount } from 'src/bri/identity/bpiAccounts/models/bpiAccount';
-import { BpiSubject } from 'src/bri/identity/bpiSubjects/models/bpiSubject';
+import { uuid } from 'uuidv4';
+import { BpiAccount } from '../../bri/identity/bpiAccounts/models/bpiAccount';
+import { BpiSubject } from '../../bri/identity/bpiSubjects/models/bpiSubject';
 import {
   BpiSubjectRole,
   BpiSubjectRoleName,
-} from 'src/bri/identity/bpiSubjects/models/bpiSubjectRole';
-import { Workstep } from 'src/bri/workgroup/worksteps/models/workstep';
-import { uuid } from 'uuidv4';
+} from '../../bri/identity/bpiSubjects/models/bpiSubjectRole';
+import { Workflow } from '../../bri/workgroup/workflows/models/workflow';
+import { Workstep } from '../../bri/workgroup/worksteps/models/workstep';
 import {
   BpiSubjectAccountBuilder,
   BpiSubjectBuilder,
@@ -13,7 +14,6 @@ import {
   WorkgroupBuilder,
   WorkstepBuilder,
 } from './builders';
-import { Workflow } from 'src/bri/workgroup/workflows/models/workflow';
 
 // A place to encapsulate  creation of test data objects used for controller testing.
 // These objects will later be used to mock prisma.client calls only once during test bootstrap

--- a/examples/bri-3/src/shared/testing/testData.helper.ts
+++ b/examples/bri-3/src/shared/testing/testData.helper.ts
@@ -110,7 +110,7 @@ export class TestDataHelper {
   ) => {
     const bpiAccount = new BpiAccountBuilder()
       .setId(uuid())
-      .setNonce(123)
+      .setNonce(0)
       .setOwnerBpiSubjectAccounts(ownerBpiSubjectAccounts)
       .setAuthorizationCondition('authorization condition')
       .setStateObjectProverSystem('prover system')

--- a/examples/bri-3/src/shared/testing/testData.helper.ts
+++ b/examples/bri-3/src/shared/testing/testData.helper.ts
@@ -1,5 +1,6 @@
 import { uuid } from 'uuidv4';
 import { BpiAccount } from '../../bri/identity/bpiAccounts/models/bpiAccount';
+import { BpiSubjectAccount } from '../../bri/identity/bpiSubjectAccounts/models/bpiSubjectAccount';
 import { BpiSubject } from '../../bri/identity/bpiSubjects/models/bpiSubject';
 import {
   BpiSubjectRole,
@@ -8,6 +9,7 @@ import {
 import { Workflow } from '../../bri/workgroup/workflows/models/workflow';
 import { Workstep } from '../../bri/workgroup/worksteps/models/workstep';
 import {
+  BpiAccountBuilder,
   BpiSubjectAccountBuilder,
   BpiSubjectBuilder,
   WorkflowBuilder,
@@ -33,14 +35,15 @@ export class TestDataHelper {
   };
 
   public static createTestWorkflow = (
+    workgroupId: string,
     worksteps: Workstep[],
     bpiAccount: BpiAccount,
   ) => {
     const workflow = new WorkflowBuilder()
-      .setId('123')
+      .setId(uuid())
       .setName('Example Workflow')
       .setWorksteps(worksteps)
-      .setWorkgroupId('456')
+      .setWorkgroupId(workgroupId)
       .setBpiAccount(bpiAccount)
       .build();
 
@@ -66,12 +69,14 @@ export class TestDataHelper {
   };
 
   public static createWorkgroup = (
+    id: string,
     admins: BpiSubject[],
     participants: BpiSubject[],
     worksteps: Workstep[],
     workflows: Workflow[],
   ) => {
     const workgroup = new WorkgroupBuilder()
+      .setId(id)
       .setAdministrators(admins)
       .setSecurityPolicy('security policy')
       .setPrivacyPolicy('privacy policy')
@@ -98,5 +103,20 @@ export class TestDataHelper {
       .build();
 
     return bpiSubjectAccount;
+  };
+
+  public static createBpiAccount = (
+    ownerBpiSubjectAccounts: BpiSubjectAccount[],
+  ) => {
+    const bpiAccount = new BpiAccountBuilder()
+      .setId(uuid())
+      .setNonce(123)
+      .setOwnerBpiSubjectAccounts(ownerBpiSubjectAccounts)
+      .setAuthorizationCondition('authorization condition')
+      .setStateObjectProverSystem('prover system')
+      .setStateObjectStorage('storage')
+      .build();
+
+    return bpiAccount;
   };
 }


### PR DESCRIPTION
# Description

Introduces Bpi Account creation during creation of a Workflow, with a reference Workflow -> BpiAccount.

## Related Issue

#668 

## Motivation and Context

It allows for workflows to store state inside a BpiAccount which is co owned by all workgroup participants

## How Has This Been Tested

Partially by unit test. Full unit tests will come once we introduce https://www.prisma.io/docs/guides/testing/unit-testing


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
