### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 
 # review when someone opens a pull request.
 
-* @skarred14 @ognjenkurtic @therecanbeonlyone1969 @Manik-Jain @skosito @Kasshern @ybittan @biscuitdey
+* @skarred14 @ognjenkurtic @therecanbeonlyone1969 @Kasshern @ybittan @biscuitdey


### PR DESCRIPTION
# Description
Removing two codeowners per governance found [here](https://github.com/eea-oasis/baseline/blob/main/docs/governance/governance.md#maintainers-) due to lack of attendance in Core Dev meetings. These members are encouraged to create a PR to rejoin the group once time allows them. 


