### PR TITLE
Update Registrar.sol

### DIFF
--- a/core/contracts/contracts/registry/Registrar.sol
+++ b/core/contracts/contracts/registry/Registrar.sol
@@ -8,7 +8,7 @@ contract Registrar {
 
     ERC1820Registry ERC1820REGISTRY;
 
-    bytes32 constant internal ERC1820_ACCEPT_MAGIC = keccak256(abi.encodePacked("ERC1820_ACCEPT_MAGIC"));
+    bytes32 immutable internal ERC1820_ACCEPT_MAGIC = keccak256(abi.encodePacked("ERC1820_ACCEPT_MAGIC"));
 
     /**
     * @dev Throws if called by any account other than the owner.


### PR DESCRIPTION
It's always advisable to use `immutable` with keccak variables

Refer this -> https://github.com/ethereum/solidity/issues/9232#issuecomment-646131646
and this -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#change-constant-to-immutable-for-keccak-variables