### PR TITLE
Fixed accounts.controller test for Merkle tree hash algh

### DIFF
--- a/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.spec.ts
+++ b/examples/bri-3/src/bri/identity/bpiAccounts/api/accounts.controller.spec.ts
@@ -38,6 +38,10 @@ describe('AccountController', () => {
   let subjectAccountStorageAgentMock: DeepMockProxy<BpiSubjectAccountStorageAgent>;
   let merkleTreeStorageAgentMock: DeepMockProxy<MerkleTreeStorageAgent>;
 
+  beforeAll(async () => {
+    process.env.MERKLE_TREE_HASH_ALGH = 'sha256';
+  });
+
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       imports: [


### PR DESCRIPTION
# Description

Fixed test for account controller with extracted var for merkle tree hash algh  

## Related issues
[SRI - Extract 'sha256' as hash algh used for the merke trees to env #743
](https://github.com/eea-oasis/baseline/issues/743)