### PR TITLE
Introduce Prisma Nested Write - Workflow Creation

### DIFF
--- a/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflowCommand.handler.ts
+++ b/examples/bri-3/src/bri/workgroup/workflows/capabilities/createWorkflow/createWorkflowCommand.handler.ts
@@ -47,15 +47,11 @@ export class CreateWorkflowCommandHandler
       'sample state object prover system',
     );
 
-    const newBpiAccount = await this.accountStorageAgent.storeNewBpiAccount(
-      newBpiAccountCandidate,
-    );
-
     const newWorkflowCandidate = this.agent.createNewWorkflow(
       command.name,
       workstepsToConnect,
       command.workgroupId,
-      newBpiAccount,
+      newBpiAccountCandidate,
     );
 
     const newWorkflow = await this.storageAgent.storeNewWorkflow(


### PR DESCRIPTION
updates create workflow to nested write of create BpiAccount and Workflow

# Description

updates the workflow creation flow so that a nested write is used to atomically create the BpiAccount and associated Workflow within the BPI

## Related Issue
#741 

## Motivation and Context

introduces first example of atomic changes to multiple records within the db 

## How Has This Been Tested

forthcoming

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Request to be added as a Code Owner/Maintainer

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I commit to abide by the Responsibilities of Code Owners/Maintainers.
